### PR TITLE
Quite a lot to add 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-
-
+#Change "FROM ubuntu:21.04 as build" to "FROM ubuntu:20.04 as build" or lower to build on your system
+#By doing so it will require you to edits things in code mainly "/libultraship/libultraship/SDLController.cpp"
+#Check comment about to uncomment stuff for Ubuntu 20.04 and probably lower.
+#I advice to find a way to update your Ubuntu but if you do not want I can not force so I can confirm that 20.04 is working if you
+#disable some things in SDLController.cpp.
+#If you test lower version nor have a better way to support a lower version feel free to tell me :)
+#Good luck ~
 FROM ubuntu:21.04 as build
 
 ENV LANG C.UTF-8

--- a/OTRExporter/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/OTRExporter/DisplayListExporter.cpp
@@ -675,7 +675,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 				uint32_t fmt = (__ & 0xE0) >> 5;
 				uint32_t siz = (__ & 0x18) >> 3;
 
-				Gfx value = gsDPSetTextureImage(fmt, siz, www - 1, (seg & 0x0FFFFFFF) + 1);
+				Gfx value = gsDPSetTextureImage(fmt, siz, www + 1, (seg & 0x0FFFFFFF) + 1);
 				word0 = value.words.w0;
 				word1 = value.words.w1;
 
@@ -693,7 +693,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 				uint32_t fmt = (__ & 0xE0) >> 5;
 				uint32_t siz = (__ & 0x18) >> 3;
 
-				Gfx value = gsDPSetTextureImage(fmt, siz, www - 1, __);
+				Gfx value = gsDPSetTextureImage(fmt, siz, www + 1, __);
 				word0 = value.words.w0 & 0x00FFFFFF;
 				word0 += (G_SETTIMG_OTR << 24);
 				//word1 = value.words.w1;

--- a/OTRExporter/OTRExporter/DisplayListExporter.cpp
+++ b/OTRExporter/OTRExporter/DisplayListExporter.cpp
@@ -653,7 +653,7 @@ void OTRExporter_DisplayList::Save(ZResource* res, const fs::path& outPath, Bina
 		{
 			int sss =	(data & 0x00FFF00000000000) >> 44;
 			int ttt =	(data & 0x00000FFF00000000) >> 32;
-			int i =		(data & 0x000000000F000000) >> 16;
+			int i =		(data & 0x000000000F000000) >> 24;
 			int uuu =	(data & 0x0000000000FFF000) >> 12;
 			int vvv=	(data & 0x0000000000000FFF);
 

--- a/libultraship/libultraship/ConfigFile.cpp
+++ b/libultraship/libultraship/ConfigFile.cpp
@@ -2,6 +2,7 @@
 #include "spdlog/spdlog.h"
 #include "GlobalCtx2.h"
 #include "Window.h"
+#include "GameSettings.h"
 
 namespace Ship {
 	ConfigFile::ConfigFile(std::shared_ptr<GlobalCtx2> Context, const std::string& Path) : Context(Context), Path(Path), File(Path.c_str()) {
@@ -148,6 +149,8 @@ namespace Ship {
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKLEFT)] = std::to_string(0x01E);
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKDOWN)] = std::to_string(0x01F);
 		(*this)["KEYBOARD CONTROLLER BINDING 4"][STR(BTN_STICKUP)] = std::to_string(0x011);
+
+		(*this)["ENHANCEMENT SETTINGS"]["TEXT_SPEED"] = "1";
 
 		(*this)["SDL CONTROLLER 1"]["GUID"] = "";
 		(*this)["SDL CONTROLLER 2"]["GUID"] = "";

--- a/libultraship/libultraship/Cvar.cpp
+++ b/libultraship/libultraship/Cvar.cpp
@@ -36,6 +36,17 @@ extern "C" float CVar_GetFloat(const char* name, float defaultValue) {
     return defaultValue;
 }
 
+extern "C" int CVar_GetInt(const char* name, int defaultValue) {
+    CVar* cvar = CVar_Get(name);
+
+    if (cvar != nullptr) {
+        if (cvar->type == CVAR_TYPE_INT)
+            return cvar->value.valueInt;
+    }
+
+    return defaultValue;
+}
+
 extern "C" char* CVar_GetString(const char* name, char* defaultValue) {
     CVar* cvar = CVar_Get(name);
 
@@ -77,6 +88,15 @@ void CVar_SetString(const char* name, char* value) {
     cvar->value.valueStr = value;
 }
 
+void CVar_SetInt(const char* name, int value) {
+    CVar* cvar = CVar_Get(name);
+    if (!cvar) {
+        cvar = new CVar;
+        cvars[std::string(name)] = cvar;
+    }
+    cvar->type = CVAR_TYPE_INT;
+    cvar->value.valueInt = value;
+}
 
 extern "C" void CVar_RegisterS32(const char* name, s32 defaultValue) {
     CVar* cvar = CVar_Get(name);
@@ -97,4 +117,11 @@ extern "C" void CVar_RegisterString(const char* name, char* defaultValue) {
 
     if (cvar == nullptr)
         CVar_SetString(name, defaultValue);
+}
+
+extern "C" void CVar_RegisterInt(const char* name, int defaultValue) {
+    CVar* cvar = CVar_Get(name);
+
+    if (cvar == nullptr)
+        CVar_SetInt(name, defaultValue);
 }

--- a/libultraship/libultraship/Cvar.h
+++ b/libultraship/libultraship/Cvar.h
@@ -3,7 +3,7 @@
 
 #include <PR/ultra64/gbi.h>
 
-typedef enum CVarType { CVAR_TYPE_S32, CVAR_TYPE_FLOAT, CVAR_TYPE_STRING } CVarType;
+typedef enum CVarType { CVAR_TYPE_S32, CVAR_TYPE_FLOAT, CVAR_TYPE_STRING, CVAR_TYPE_INT } CVarType;
 
 typedef struct CVar {
     char* name;
@@ -13,6 +13,7 @@ typedef struct CVar {
         s32 valueS32;
         float valueFloat;
         char* valueStr;
+        int valueInt;
     } value;
 } CVar;
 
@@ -22,17 +23,16 @@ extern "C"
 #endif
 //#include <ultra64.h>
 
-
 CVar* CVar_Get(const char* name);
 s32 CVar_GetS32(const char* name, s32 defaultValue);
 float CVar_GetFloat(const char* name, float defaultValue);
 char* CVar_GetString(const char* name, char* defaultValue);
 void CVar_SetS32(const char* name, s32 value);
-
+int CVar_GetInt(const char* name, int defaultValue);
 void CVar_RegisterS32(const char* name, s32 defaultValue);
 void CVar_RegisterFloat(const char* name, float defaultValue);
 void CVar_RegisterString(const char* name, char* defaultValue);
-
+void CVar_RegisterInt(const char* name, int defaultValue);
 #ifdef __cplusplus
 };
 #endif
@@ -45,5 +45,7 @@ extern std::map<std::string, CVar*> cvars;
 CVar* CVar_GetVar(const char* name);
 void CVar_SetFloat(const char* name, float value);
 void CVar_SetString(const char* name, char* value);
+int CVar_GetInt(const char* name, int defaultValue);
+void CVar_SetInt(const char* name, int value);
 #endif
 #endif

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -49,6 +49,7 @@ namespace Game {
         Settings.debug.soh = stob(Conf[ConfSection]["soh_debug"]);
     	Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
         Settings.debug.buildinfos = stob(Conf[ConfSection]["hide_buildinfos"]);
+        CVar_SetS32("gBuildInfos", Settings.debug.buildinfos);
 
         // Enhancements
         Settings.enhancements.skip_text = stob(Conf[EnhancementSection]["skip_text"]);

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -48,10 +48,14 @@ namespace Game {
         Settings.debug.menu_bar = stob(Conf[ConfSection]["menu_bar"]);
         Settings.debug.soh = stob(Conf[ConfSection]["soh_debug"]);
     	Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
+        Settings.debug.buildinfos = stob(Conf[ConfSection]["hide_buildinfos"]);
 
         // Enhancements
-        Settings.enhancements.fast_text = stob(Conf[EnhancementSection]["fast_text"]);
-        CVar_SetS32("gFastText", Settings.enhancements.fast_text);
+        Settings.enhancements.skip_text = stob(Conf[EnhancementSection]["skip_text"]);
+        CVar_SetS32("gSkipText", Settings.enhancements.skip_text);
+
+        Settings.enhancements.text_speed = Ship::stoi(Conf[EnhancementSection]["text_speed"]);
+        CVar_SetS32("gTextSpeed", Settings.enhancements.text_speed);
 
         Settings.enhancements.disable_lod = stob(Conf[EnhancementSection]["disable_lod"]);
         CVar_SetS32("gDisableLOD", Settings.enhancements.disable_lod);
@@ -164,83 +168,83 @@ namespace Game {
 
         Settings.hudcolors.custom_colors = stob(Conf[HUDColorSection]["custom_colors"]);
         CVar_SetS32("gCustomColors", Settings.hudcolors.custom_colors);
-          //hearts main colors
-          Settings.hudcolors.ccheartsprimr = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimr"]) : Settings.hudcolors.ccheartsprimr;
-          CVar_SetInt("gCCHeartsPrimR", Settings.hudcolors.ccheartsprimr);
-          Settings.hudcolors.ccheartsprimg = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimg"]) : Settings.hudcolors.ccheartsprimg;
-          CVar_SetInt("gCCHeartsPrimG", Settings.hudcolors.ccheartsprimg);
-          Settings.hudcolors.ccheartsprimb = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimb"]) : Settings.hudcolors.ccheartsprimb;
-          CVar_SetInt("gCCHeartsPrimB", Settings.hudcolors.ccheartsprimb);
-          //hearts double defense main colors
-          Settings.hudcolors.ddccheartsprimr = (Conf[HUDColorSection]["cc_ddheartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimr"]) : Settings.hudcolors.ddccheartsprimr;
-          CVar_SetInt("gDDCCHeartsPrimR", Settings.hudcolors.ddccheartsprimr);
-          Settings.hudcolors.ddccheartsprimg = (Conf[HUDColorSection]["cc_ddheartsprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimg"]) : Settings.hudcolors.ddccheartsprimg;
-          CVar_SetInt("gDDCCHeartsPrimG", Settings.hudcolors.ddccheartsprimg);
-          Settings.hudcolors.ddccheartsprimb = (Conf[HUDColorSection]["cc_ddheartsprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimb"]) : Settings.hudcolors.ddccheartsprimb;
-          CVar_SetInt("gDDCCHeartsPrimB", Settings.hudcolors.ddccheartsprimb);
-          //a button
-          Settings.hudcolors.ccabtnprimr = (Conf[HUDColorSection]["cc_abtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimr"]) : Settings.hudcolors.ccabtnprimr;
-          CVar_SetInt("gCCABtnPrimR", Settings.hudcolors.ccabtnprimr);
-          Settings.hudcolors.ccabtnprimg = (Conf[HUDColorSection]["cc_abtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimg"]) : Settings.hudcolors.ccabtnprimg;
-          CVar_SetInt("gCCABtnPrimG", Settings.hudcolors.ccabtnprimg);
-          Settings.hudcolors.ccabtnprimb = (Conf[HUDColorSection]["cc_abtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimb"]) : Settings.hudcolors.ccabtnprimb;
-          CVar_SetInt("gCCABtnPrimB", Settings.hudcolors.ccabtnprimb);
-          //b button
-          Settings.hudcolors.ccbbtnprimr = (Conf[HUDColorSection]["cc_bbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimr"]) : Settings.hudcolors.ccbbtnprimr;
-          CVar_SetInt("gCCBBtnPrimR", Settings.hudcolors.ccbbtnprimr);
-          Settings.hudcolors.ccbbtnprimg = (Conf[HUDColorSection]["cc_bbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimg"]) : Settings.hudcolors.ccbbtnprimg;
-          CVar_SetInt("gCCBBtnPrimG", Settings.hudcolors.ccbbtnprimg);
-          Settings.hudcolors.ccbbtnprimb = (Conf[HUDColorSection]["cc_bbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimb"]) : Settings.hudcolors.ccbbtnprimb;
-          CVar_SetInt("gCCBBtnPrimB", Settings.hudcolors.ccbbtnprimb);
-          //start button
-          Settings.hudcolors.ccstartbtnprimr = (Conf[HUDColorSection]["cc_startbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimr"]) : Settings.hudcolors.ccstartbtnprimr;
-          CVar_SetInt("gCCStartBtnPrimR", Settings.hudcolors.ccstartbtnprimr);
-          Settings.hudcolors.ccstartbtnprimg = (Conf[HUDColorSection]["cc_startbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimg"]) : Settings.hudcolors.ccstartbtnprimg;
-          CVar_SetInt("gCCStartBtnPrimG", Settings.hudcolors.ccstartbtnprimg);
-          Settings.hudcolors.ccstartbtnprimb = (Conf[HUDColorSection]["cc_startbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimb"]) : Settings.hudcolors.ccstartbtnprimb;
-          CVar_SetInt("gCCStartBtnPrimB", Settings.hudcolors.ccstartbtnprimb);
-          //c button
-          Settings.hudcolors.cccbtnprimr = (Conf[HUDColorSection]["cc_cbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimr"]) : Settings.hudcolors.cccbtnprimr;
-          CVar_SetInt("gCCCBtnPrimR", Settings.hudcolors.cccbtnprimr);
-          Settings.hudcolors.cccbtnprimg = (Conf[HUDColorSection]["cc_cbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimg"]) : Settings.hudcolors.cccbtnprimg;
-          CVar_SetInt("gCCCBtnPrimG", Settings.hudcolors.cccbtnprimg);
-          Settings.hudcolors.cccbtnprimb = (Conf[HUDColorSection]["cc_cbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimb"]) : Settings.hudcolors.cccbtnprimb;
-          CVar_SetInt("gCCCBtnPrimB", Settings.hudcolors.cccbtnprimb);
-          //magic metter borders
-          Settings.hudcolors.ccmagicborderprimr = (Conf[HUDColorSection]["cc_magicborderprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimr"]) : Settings.hudcolors.ccmagicborderprimr;
-          CVar_SetInt("gCCMagicBorderPrimR", Settings.hudcolors.ccmagicborderprimr);
-          Settings.hudcolors.ccmagicborderprimg = (Conf[HUDColorSection]["cc_magicborderprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimg"]) : Settings.hudcolors.ccmagicborderprimg;
-          CVar_SetInt("gCCMagicBorderPrimG", Settings.hudcolors.ccmagicborderprimg);
-          Settings.hudcolors.ccmagicborderprimb = (Conf[HUDColorSection]["cc_magicborderprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimb"]) : Settings.hudcolors.ccmagicborderprimb;
-          CVar_SetInt("gCCMagicBorderPrimB", Settings.hudcolors.ccmagicborderprimb);
-          //magic metter remaining 
-          Settings.hudcolors.ccmagicprimr = (Conf[HUDColorSection]["cc_magicprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimr"]) : Settings.hudcolors.ccmagicprimr;
-          CVar_SetInt("gCCMagicPrimR", Settings.hudcolors.ccmagicprimr);
-          Settings.hudcolors.ccmagicprimg = (Conf[HUDColorSection]["cc_magicprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimg"]) : Settings.hudcolors.ccmagicprimg;
-          CVar_SetInt("gCCMagicPrimG", Settings.hudcolors.ccmagicprimg);
-          Settings.hudcolors.ccmagicprimb = (Conf[HUDColorSection]["cc_magicprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimb"]) : Settings.hudcolors.ccmagicprimb;
-          CVar_SetInt("gCCMagicPrimB", Settings.hudcolors.ccmagicprimb);
-          //magic metter being used
-          Settings.hudcolors.ccmagicuseprimr = (Conf[HUDColorSection]["cc_magicuseprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimr"]) : Settings.hudcolors.ccmagicuseprimr;
-          CVar_SetInt("gCCMagicUsePrimR", Settings.hudcolors.ccmagicuseprimr);
-          Settings.hudcolors.ccmagicuseprimg = (Conf[HUDColorSection]["cc_magicuseprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimg"]) : Settings.hudcolors.ccmagicuseprimg;
-          CVar_SetInt("gCCMagicUsePrimG", Settings.hudcolors.ccmagicuseprimg);
-          Settings.hudcolors.ccmagicuseprimb = (Conf[HUDColorSection]["cc_magicuseprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimb"]) : Settings.hudcolors.ccmagicuseprimb;
-          CVar_SetInt("gCCMagicUsePrimB", Settings.hudcolors.ccmagicuseprimb);
-          //minimap
-          Settings.hudcolors.ccminimapprimr = (Conf[HUDColorSection]["cc_minimapprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimr"]) : Settings.hudcolors.ccminimapprimr;
-          CVar_SetInt("gCCMinimapPrimR", Settings.hudcolors.ccminimapprimr);
-          Settings.hudcolors.ccminimapprimg = (Conf[HUDColorSection]["cc_minimapprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimg"]) : Settings.hudcolors.ccminimapprimg;
-          CVar_SetInt("gCCMinimapPrimG", Settings.hudcolors.ccminimapprimg);
-          Settings.hudcolors.ccminimapprimb = (Conf[HUDColorSection]["cc_minimapprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimb"]) : Settings.hudcolors.ccminimapprimb;
-          CVar_SetInt("gCCMinimapPrimB", Settings.hudcolors.ccminimapprimb);
-          //rupee icon
-          Settings.hudcolors.ccrupeeprimr = (Conf[HUDColorSection]["cc_rupeeprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimr"]) : Settings.hudcolors.ccrupeeprimr;
-          CVar_SetInt("gCCRupeePrimR", Settings.hudcolors.ccrupeeprimr);
-          Settings.hudcolors.ccrupeeprimg = (Conf[HUDColorSection]["cc_rupeeprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimg"]) : Settings.hudcolors.ccrupeeprimg;
-          CVar_SetInt("gCCRupeePrimG", Settings.hudcolors.ccrupeeprimg);
-          Settings.hudcolors.ccrupeeprimb = (Conf[HUDColorSection]["cc_rupeeprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimb"]) : Settings.hudcolors.ccrupeeprimb;
-          CVar_SetInt("gCCRupeePrimB", Settings.hudcolors.ccrupeeprimb);
+        //hearts main colors
+        Settings.hudcolors.ccheartsprimr = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimr"]) : Settings.hudcolors.ccheartsprimr;
+        CVar_SetInt("gCCHeartsPrimR", Settings.hudcolors.ccheartsprimr);
+        Settings.hudcolors.ccheartsprimg = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimg"]) : Settings.hudcolors.ccheartsprimg;
+        CVar_SetInt("gCCHeartsPrimG", Settings.hudcolors.ccheartsprimg);
+        Settings.hudcolors.ccheartsprimb = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimb"]) : Settings.hudcolors.ccheartsprimb;
+        CVar_SetInt("gCCHeartsPrimB", Settings.hudcolors.ccheartsprimb);
+        //hearts double defense main colors
+        Settings.hudcolors.ddccheartsprimr = (Conf[HUDColorSection]["cc_ddheartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimr"]) : Settings.hudcolors.ddccheartsprimr;
+        CVar_SetInt("gDDCCHeartsPrimR", Settings.hudcolors.ddccheartsprimr);
+        Settings.hudcolors.ddccheartsprimg = (Conf[HUDColorSection]["cc_ddheartsprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimg"]) : Settings.hudcolors.ddccheartsprimg;
+        CVar_SetInt("gDDCCHeartsPrimG", Settings.hudcolors.ddccheartsprimg);
+        Settings.hudcolors.ddccheartsprimb = (Conf[HUDColorSection]["cc_ddheartsprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimb"]) : Settings.hudcolors.ddccheartsprimb;
+        CVar_SetInt("gDDCCHeartsPrimB", Settings.hudcolors.ddccheartsprimb);
+        //a button
+        Settings.hudcolors.ccabtnprimr = (Conf[HUDColorSection]["cc_abtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimr"]) : Settings.hudcolors.ccabtnprimr;
+        CVar_SetInt("gCCABtnPrimR", Settings.hudcolors.ccabtnprimr);
+        Settings.hudcolors.ccabtnprimg = (Conf[HUDColorSection]["cc_abtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimg"]) : Settings.hudcolors.ccabtnprimg;
+        CVar_SetInt("gCCABtnPrimG", Settings.hudcolors.ccabtnprimg);
+        Settings.hudcolors.ccabtnprimb = (Conf[HUDColorSection]["cc_abtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimb"]) : Settings.hudcolors.ccabtnprimb;
+        CVar_SetInt("gCCABtnPrimB", Settings.hudcolors.ccabtnprimb);
+        //b button
+        Settings.hudcolors.ccbbtnprimr = (Conf[HUDColorSection]["cc_bbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimr"]) : Settings.hudcolors.ccbbtnprimr;
+        CVar_SetInt("gCCBBtnPrimR", Settings.hudcolors.ccbbtnprimr);
+        Settings.hudcolors.ccbbtnprimg = (Conf[HUDColorSection]["cc_bbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimg"]) : Settings.hudcolors.ccbbtnprimg;
+        CVar_SetInt("gCCBBtnPrimG", Settings.hudcolors.ccbbtnprimg);
+        Settings.hudcolors.ccbbtnprimb = (Conf[HUDColorSection]["cc_bbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimb"]) : Settings.hudcolors.ccbbtnprimb;
+        CVar_SetInt("gCCBBtnPrimB", Settings.hudcolors.ccbbtnprimb);
+        //start button
+        Settings.hudcolors.ccstartbtnprimr = (Conf[HUDColorSection]["cc_startbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimr"]) : Settings.hudcolors.ccstartbtnprimr;
+        CVar_SetInt("gCCStartBtnPrimR", Settings.hudcolors.ccstartbtnprimr);
+        Settings.hudcolors.ccstartbtnprimg = (Conf[HUDColorSection]["cc_startbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimg"]) : Settings.hudcolors.ccstartbtnprimg;
+        CVar_SetInt("gCCStartBtnPrimG", Settings.hudcolors.ccstartbtnprimg);
+        Settings.hudcolors.ccstartbtnprimb = (Conf[HUDColorSection]["cc_startbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimb"]) : Settings.hudcolors.ccstartbtnprimb;
+        CVar_SetInt("gCCStartBtnPrimB", Settings.hudcolors.ccstartbtnprimb);
+        //c button
+        Settings.hudcolors.cccbtnprimr = (Conf[HUDColorSection]["cc_cbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimr"]) : Settings.hudcolors.cccbtnprimr;
+        CVar_SetInt("gCCCBtnPrimR", Settings.hudcolors.cccbtnprimr);
+        Settings.hudcolors.cccbtnprimg = (Conf[HUDColorSection]["cc_cbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimg"]) : Settings.hudcolors.cccbtnprimg;
+        CVar_SetInt("gCCCBtnPrimG", Settings.hudcolors.cccbtnprimg);
+        Settings.hudcolors.cccbtnprimb = (Conf[HUDColorSection]["cc_cbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimb"]) : Settings.hudcolors.cccbtnprimb;
+        CVar_SetInt("gCCCBtnPrimB", Settings.hudcolors.cccbtnprimb);
+        //magic metter borders
+        Settings.hudcolors.ccmagicborderprimr = (Conf[HUDColorSection]["cc_magicborderprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimr"]) : Settings.hudcolors.ccmagicborderprimr;
+        CVar_SetInt("gCCMagicBorderPrimR", Settings.hudcolors.ccmagicborderprimr);
+        Settings.hudcolors.ccmagicborderprimg = (Conf[HUDColorSection]["cc_magicborderprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimg"]) : Settings.hudcolors.ccmagicborderprimg;
+        CVar_SetInt("gCCMagicBorderPrimG", Settings.hudcolors.ccmagicborderprimg);
+        Settings.hudcolors.ccmagicborderprimb = (Conf[HUDColorSection]["cc_magicborderprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimb"]) : Settings.hudcolors.ccmagicborderprimb;
+        CVar_SetInt("gCCMagicBorderPrimB", Settings.hudcolors.ccmagicborderprimb);
+        //magic metter remaining 
+        Settings.hudcolors.ccmagicprimr = (Conf[HUDColorSection]["cc_magicprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimr"]) : Settings.hudcolors.ccmagicprimr;
+        CVar_SetInt("gCCMagicPrimR", Settings.hudcolors.ccmagicprimr);
+        Settings.hudcolors.ccmagicprimg = (Conf[HUDColorSection]["cc_magicprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimg"]) : Settings.hudcolors.ccmagicprimg;
+        CVar_SetInt("gCCMagicPrimG", Settings.hudcolors.ccmagicprimg);
+        Settings.hudcolors.ccmagicprimb = (Conf[HUDColorSection]["cc_magicprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimb"]) : Settings.hudcolors.ccmagicprimb;
+        CVar_SetInt("gCCMagicPrimB", Settings.hudcolors.ccmagicprimb);
+        //magic metter being used
+        Settings.hudcolors.ccmagicuseprimr = (Conf[HUDColorSection]["cc_magicuseprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimr"]) : Settings.hudcolors.ccmagicuseprimr;
+        CVar_SetInt("gCCMagicUsePrimR", Settings.hudcolors.ccmagicuseprimr);
+        Settings.hudcolors.ccmagicuseprimg = (Conf[HUDColorSection]["cc_magicuseprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimg"]) : Settings.hudcolors.ccmagicuseprimg;
+        CVar_SetInt("gCCMagicUsePrimG", Settings.hudcolors.ccmagicuseprimg);
+        Settings.hudcolors.ccmagicuseprimb = (Conf[HUDColorSection]["cc_magicuseprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimb"]) : Settings.hudcolors.ccmagicuseprimb;
+        CVar_SetInt("gCCMagicUsePrimB", Settings.hudcolors.ccmagicuseprimb);
+        //minimap
+        Settings.hudcolors.ccminimapprimr = (Conf[HUDColorSection]["cc_minimapprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimr"]) : Settings.hudcolors.ccminimapprimr;
+        CVar_SetInt("gCCMinimapPrimR", Settings.hudcolors.ccminimapprimr);
+        Settings.hudcolors.ccminimapprimg = (Conf[HUDColorSection]["cc_minimapprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimg"]) : Settings.hudcolors.ccminimapprimg;
+        CVar_SetInt("gCCMinimapPrimG", Settings.hudcolors.ccminimapprimg);
+        Settings.hudcolors.ccminimapprimb = (Conf[HUDColorSection]["cc_minimapprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimb"]) : Settings.hudcolors.ccminimapprimb;
+        CVar_SetInt("gCCMinimapPrimB", Settings.hudcolors.ccminimapprimb);
+        //rupee icon
+        Settings.hudcolors.ccrupeeprimr = (Conf[HUDColorSection]["cc_rupeeprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimr"]) : Settings.hudcolors.ccrupeeprimr;
+        CVar_SetInt("gCCRupeePrimR", Settings.hudcolors.ccrupeeprimr);
+        Settings.hudcolors.ccrupeeprimg = (Conf[HUDColorSection]["cc_rupeeprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimg"]) : Settings.hudcolors.ccrupeeprimg;
+        CVar_SetInt("gCCRupeePrimG", Settings.hudcolors.ccrupeeprimg);
+        Settings.hudcolors.ccrupeeprimb = (Conf[HUDColorSection]["cc_rupeeprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimb"]) : Settings.hudcolors.ccrupeeprimb;
+        CVar_SetInt("gCCRupeePrimB", Settings.hudcolors.ccrupeeprimb);
 
         Settings.languages.set_eng = stob(Conf[LanguagesSection]["set_eng"]);
         CVar_SetS32("gSetENG", Settings.languages.set_eng);
@@ -263,6 +267,7 @@ namespace Game {
         Conf[ConfSection]["menu_bar"] = std::to_string(Settings.debug.menu_bar);
         Conf[ConfSection]["soh_debug"] = std::to_string(Settings.debug.soh);
         Conf[ConfSection]["n64_mode"] = std::to_string(Settings.debug.n64mode);
+        Conf[ConfSection]["hide_buildinfos"] = std::to_string(Settings.debug.buildinfos);
 
         // Audio
         Conf[AudioSection]["master"] = std::to_string(Settings.audio.master);
@@ -272,7 +277,8 @@ namespace Game {
         Conf[AudioSection]["fanfare"] = std::to_string(Settings.audio.fanfare);
 
         // Enhancements
-        Conf[EnhancementSection]["fast_text"] = std::to_string(Settings.enhancements.fast_text);
+        Conf[EnhancementSection]["skip_text"] = std::to_string(Settings.enhancements.skip_text);
+        Conf[EnhancementSection]["text_speed"] = std::to_string(Settings.enhancements.text_speed);
         Conf[EnhancementSection]["disable_lod"] = std::to_string(Settings.enhancements.disable_lod);
         Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);
         Conf[EnhancementSection]["minimal_ui"] = std::to_string(Settings.enhancements.minimal_ui);

--- a/libultraship/libultraship/GameSettings.cpp
+++ b/libultraship/libultraship/GameSettings.cpp
@@ -28,6 +28,7 @@ namespace Game {
     const std::string ControllerSection = CONTROLLER_SECTION;
     const std::string EnhancementSection = ENHANCEMENTS_SECTION;
     const std::string CheatSection = CHEATS_SECTION;
+    const std::string HUDColorSection = HUDCOLOR_SECTION;
     const std::string LanguagesSection = LANGUAGES_SECTION;
 
     void UpdateAudio() {
@@ -46,8 +47,7 @@ namespace Game {
         SohImGui::console->opened = stob(Conf[ConfSection]["console"]);
         Settings.debug.menu_bar = stob(Conf[ConfSection]["menu_bar"]);
         Settings.debug.soh = stob(Conf[ConfSection]["soh_debug"]);
-
-    	   Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
+    	Settings.debug.n64mode = stob(Conf[ConfSection]["n64_mode"]);
 
         // Enhancements
         Settings.enhancements.fast_text = stob(Conf[EnhancementSection]["fast_text"]);
@@ -68,9 +68,6 @@ namespace Game {
         Settings.enhancements.newdrops = stob(Conf[EnhancementSection]["newdrops"]);
         CVar_SetS32("gNewDrops", Settings.enhancements.newdrops);
 
-        Settings.enhancements.n64color = stob(Conf[EnhancementSection]["n64color"]);
-        CVar_SetS32("gN64Color", Settings.enhancements.n64color);
-
         Settings.enhancements.visualagony = stob(Conf[EnhancementSection]["visualagony"]);
         CVar_SetS32("gVisualAgony", Settings.enhancements.visualagony);
 
@@ -78,7 +75,8 @@ namespace Game {
         CVar_SetS32("gMMBunnyHood", Settings.enhancements.mm_bunny_hood);
 
         Settings.enhancements.uniform_lr = stob(Conf[EnhancementSection]["uniform_lr"]);
-        CVar_SetS32("gUniformLR", Settings.enhancements.uniform_lr);
+        //CVar_SetS32("gUniformLR", Settings.enhancements.uniform_lr);
+        CVar_SetS32("gUniformLR", 1);
 
         // Audio
         Settings.audio.master = Ship::stof(Conf[AudioSection]["master"]);
@@ -158,6 +156,92 @@ namespace Game {
         Settings.cheats.freeze_time = stob(Conf[CheatSection]["freeze_time"]);
         CVar_SetS32("gFreezeTime", Settings.cheats.freeze_time);
 
+        Settings.hudcolors.n64_colors = stob(Conf[HUDColorSection]["n64_colors"]);
+        CVar_SetS32("gN64Colors", Settings.hudcolors.n64_colors);
+
+        Settings.hudcolors.gc_colors = stob(Conf[HUDColorSection]["gc_colors"]);
+        CVar_SetS32("gGameCubeColors", Settings.hudcolors.gc_colors);
+
+        Settings.hudcolors.custom_colors = stob(Conf[HUDColorSection]["custom_colors"]);
+        CVar_SetS32("gCustomColors", Settings.hudcolors.custom_colors);
+          //hearts main colors
+          Settings.hudcolors.ccheartsprimr = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimr"]) : Settings.hudcolors.ccheartsprimr;
+          CVar_SetInt("gCCHeartsPrimR", Settings.hudcolors.ccheartsprimr);
+          Settings.hudcolors.ccheartsprimg = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimg"]) : Settings.hudcolors.ccheartsprimg;
+          CVar_SetInt("gCCHeartsPrimG", Settings.hudcolors.ccheartsprimg);
+          Settings.hudcolors.ccheartsprimb = (Conf[HUDColorSection]["cc_heartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_heartsprimb"]) : Settings.hudcolors.ccheartsprimb;
+          CVar_SetInt("gCCHeartsPrimB", Settings.hudcolors.ccheartsprimb);
+          //hearts double defense main colors
+          Settings.hudcolors.ddccheartsprimr = (Conf[HUDColorSection]["cc_ddheartsprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimr"]) : Settings.hudcolors.ddccheartsprimr;
+          CVar_SetInt("gDDCCHeartsPrimR", Settings.hudcolors.ddccheartsprimr);
+          Settings.hudcolors.ddccheartsprimg = (Conf[HUDColorSection]["cc_ddheartsprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimg"]) : Settings.hudcolors.ddccheartsprimg;
+          CVar_SetInt("gDDCCHeartsPrimG", Settings.hudcolors.ddccheartsprimg);
+          Settings.hudcolors.ddccheartsprimb = (Conf[HUDColorSection]["cc_ddheartsprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_ddheartsprimb"]) : Settings.hudcolors.ddccheartsprimb;
+          CVar_SetInt("gDDCCHeartsPrimB", Settings.hudcolors.ddccheartsprimb);
+          //a button
+          Settings.hudcolors.ccabtnprimr = (Conf[HUDColorSection]["cc_abtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimr"]) : Settings.hudcolors.ccabtnprimr;
+          CVar_SetInt("gCCABtnPrimR", Settings.hudcolors.ccabtnprimr);
+          Settings.hudcolors.ccabtnprimg = (Conf[HUDColorSection]["cc_abtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimg"]) : Settings.hudcolors.ccabtnprimg;
+          CVar_SetInt("gCCABtnPrimG", Settings.hudcolors.ccabtnprimg);
+          Settings.hudcolors.ccabtnprimb = (Conf[HUDColorSection]["cc_abtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_abtnprimb"]) : Settings.hudcolors.ccabtnprimb;
+          CVar_SetInt("gCCABtnPrimB", Settings.hudcolors.ccabtnprimb);
+          //b button
+          Settings.hudcolors.ccbbtnprimr = (Conf[HUDColorSection]["cc_bbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimr"]) : Settings.hudcolors.ccbbtnprimr;
+          CVar_SetInt("gCCBBtnPrimR", Settings.hudcolors.ccbbtnprimr);
+          Settings.hudcolors.ccbbtnprimg = (Conf[HUDColorSection]["cc_bbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimg"]) : Settings.hudcolors.ccbbtnprimg;
+          CVar_SetInt("gCCBBtnPrimG", Settings.hudcolors.ccbbtnprimg);
+          Settings.hudcolors.ccbbtnprimb = (Conf[HUDColorSection]["cc_bbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_bbtnprimb"]) : Settings.hudcolors.ccbbtnprimb;
+          CVar_SetInt("gCCBBtnPrimB", Settings.hudcolors.ccbbtnprimb);
+          //start button
+          Settings.hudcolors.ccstartbtnprimr = (Conf[HUDColorSection]["cc_startbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimr"]) : Settings.hudcolors.ccstartbtnprimr;
+          CVar_SetInt("gCCStartBtnPrimR", Settings.hudcolors.ccstartbtnprimr);
+          Settings.hudcolors.ccstartbtnprimg = (Conf[HUDColorSection]["cc_startbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimg"]) : Settings.hudcolors.ccstartbtnprimg;
+          CVar_SetInt("gCCStartBtnPrimG", Settings.hudcolors.ccstartbtnprimg);
+          Settings.hudcolors.ccstartbtnprimb = (Conf[HUDColorSection]["cc_startbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_startbtnprimb"]) : Settings.hudcolors.ccstartbtnprimb;
+          CVar_SetInt("gCCStartBtnPrimB", Settings.hudcolors.ccstartbtnprimb);
+          //c button
+          Settings.hudcolors.cccbtnprimr = (Conf[HUDColorSection]["cc_cbtnprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimr"]) : Settings.hudcolors.cccbtnprimr;
+          CVar_SetInt("gCCCBtnPrimR", Settings.hudcolors.cccbtnprimr);
+          Settings.hudcolors.cccbtnprimg = (Conf[HUDColorSection]["cc_cbtnprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimg"]) : Settings.hudcolors.cccbtnprimg;
+          CVar_SetInt("gCCCBtnPrimG", Settings.hudcolors.cccbtnprimg);
+          Settings.hudcolors.cccbtnprimb = (Conf[HUDColorSection]["cc_cbtnprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_cbtnprimb"]) : Settings.hudcolors.cccbtnprimb;
+          CVar_SetInt("gCCCBtnPrimB", Settings.hudcolors.cccbtnprimb);
+          //magic metter borders
+          Settings.hudcolors.ccmagicborderprimr = (Conf[HUDColorSection]["cc_magicborderprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimr"]) : Settings.hudcolors.ccmagicborderprimr;
+          CVar_SetInt("gCCMagicBorderPrimR", Settings.hudcolors.ccmagicborderprimr);
+          Settings.hudcolors.ccmagicborderprimg = (Conf[HUDColorSection]["cc_magicborderprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimg"]) : Settings.hudcolors.ccmagicborderprimg;
+          CVar_SetInt("gCCMagicBorderPrimG", Settings.hudcolors.ccmagicborderprimg);
+          Settings.hudcolors.ccmagicborderprimb = (Conf[HUDColorSection]["cc_magicborderprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicborderprimb"]) : Settings.hudcolors.ccmagicborderprimb;
+          CVar_SetInt("gCCMagicBorderPrimB", Settings.hudcolors.ccmagicborderprimb);
+          //magic metter remaining 
+          Settings.hudcolors.ccmagicprimr = (Conf[HUDColorSection]["cc_magicprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimr"]) : Settings.hudcolors.ccmagicprimr;
+          CVar_SetInt("gCCMagicPrimR", Settings.hudcolors.ccmagicprimr);
+          Settings.hudcolors.ccmagicprimg = (Conf[HUDColorSection]["cc_magicprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimg"]) : Settings.hudcolors.ccmagicprimg;
+          CVar_SetInt("gCCMagicPrimG", Settings.hudcolors.ccmagicprimg);
+          Settings.hudcolors.ccmagicprimb = (Conf[HUDColorSection]["cc_magicprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicprimb"]) : Settings.hudcolors.ccmagicprimb;
+          CVar_SetInt("gCCMagicPrimB", Settings.hudcolors.ccmagicprimb);
+          //magic metter being used
+          Settings.hudcolors.ccmagicuseprimr = (Conf[HUDColorSection]["cc_magicuseprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimr"]) : Settings.hudcolors.ccmagicuseprimr;
+          CVar_SetInt("gCCMagicUsePrimR", Settings.hudcolors.ccmagicuseprimr);
+          Settings.hudcolors.ccmagicuseprimg = (Conf[HUDColorSection]["cc_magicuseprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimg"]) : Settings.hudcolors.ccmagicuseprimg;
+          CVar_SetInt("gCCMagicUsePrimG", Settings.hudcolors.ccmagicuseprimg);
+          Settings.hudcolors.ccmagicuseprimb = (Conf[HUDColorSection]["cc_magicuseprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_magicuseprimb"]) : Settings.hudcolors.ccmagicuseprimb;
+          CVar_SetInt("gCCMagicUsePrimB", Settings.hudcolors.ccmagicuseprimb);
+          //minimap
+          Settings.hudcolors.ccminimapprimr = (Conf[HUDColorSection]["cc_minimapprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimr"]) : Settings.hudcolors.ccminimapprimr;
+          CVar_SetInt("gCCMinimapPrimR", Settings.hudcolors.ccminimapprimr);
+          Settings.hudcolors.ccminimapprimg = (Conf[HUDColorSection]["cc_minimapprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimg"]) : Settings.hudcolors.ccminimapprimg;
+          CVar_SetInt("gCCMinimapPrimG", Settings.hudcolors.ccminimapprimg);
+          Settings.hudcolors.ccminimapprimb = (Conf[HUDColorSection]["cc_minimapprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_minimapprimb"]) : Settings.hudcolors.ccminimapprimb;
+          CVar_SetInt("gCCMinimapPrimB", Settings.hudcolors.ccminimapprimb);
+          //rupee icon
+          Settings.hudcolors.ccrupeeprimr = (Conf[HUDColorSection]["cc_rupeeprimr"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimr"]) : Settings.hudcolors.ccrupeeprimr;
+          CVar_SetInt("gCCRupeePrimR", Settings.hudcolors.ccrupeeprimr);
+          Settings.hudcolors.ccrupeeprimg = (Conf[HUDColorSection]["cc_rupeeprimg"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimg"]) : Settings.hudcolors.ccrupeeprimg;
+          CVar_SetInt("gCCRupeePrimG", Settings.hudcolors.ccrupeeprimg);
+          Settings.hudcolors.ccrupeeprimb = (Conf[HUDColorSection]["cc_rupeeprimb"] != "") ? Ship::stoi(Conf[HUDColorSection]["cc_rupeeprimb"]) : Settings.hudcolors.ccrupeeprimb;
+          CVar_SetInt("gCCRupeePrimB", Settings.hudcolors.ccrupeeprimb);
+
         Settings.languages.set_eng = stob(Conf[LanguagesSection]["set_eng"]);
         CVar_SetS32("gSetENG", Settings.languages.set_eng);
 
@@ -193,10 +277,9 @@ namespace Game {
         Conf[EnhancementSection]["animated_pause_menu"] = std::to_string(Settings.enhancements.animated_pause_menu);
         Conf[EnhancementSection]["minimal_ui"] = std::to_string(Settings.enhancements.minimal_ui);
         Conf[EnhancementSection]["dynamic_wallet_icon"] = std::to_string(Settings.enhancements.dynamic_wallet_icon);
-    		Conf[EnhancementSection]["newdrops"] = std::to_string(Settings.enhancements.newdrops);
-    		Conf[EnhancementSection]["n64color"] = std::to_string(Settings.enhancements.n64color);
+    	Conf[EnhancementSection]["newdrops"] = std::to_string(Settings.enhancements.newdrops);
         Conf[EnhancementSection]["visualagony"] = std::to_string(Settings.enhancements.visualagony);
-    	  Conf[EnhancementSection]["mm_bunny_hood"] = std::to_string(Settings.enhancements.mm_bunny_hood);
+    	Conf[EnhancementSection]["mm_bunny_hood"] = std::to_string(Settings.enhancements.mm_bunny_hood);
         Conf[EnhancementSection]["uniform_lr"] = std::to_string(Settings.enhancements.uniform_lr);
 
         // Controllers
@@ -218,6 +301,44 @@ namespace Game {
         Conf[CheatSection]["climb_everything"] = std::to_string(Settings.cheats.climb_everything);
         Conf[CheatSection]["moon_jump_on_l"] = std::to_string(Settings.cheats.moon_jump_on_l);
         Conf[CheatSection]["super_tunic"] = std::to_string(Settings.cheats.super_tunic);
+
+        //HUD Color
+        Conf[HUDColorSection]["n64_colors"] = std::to_string(Settings.hudcolors.n64_colors);
+        Conf[HUDColorSection]["gc_colors"] = std::to_string(Settings.hudcolors.gc_colors);
+        Conf[HUDColorSection]["custom_colors"] = std::to_string(Settings.hudcolors.custom_colors);
+        Conf[HUDColorSection]["cc_heartsprimr"] = std::to_string(Settings.hudcolors.ccheartsprimr);
+        Conf[HUDColorSection]["cc_heartsprimg"] = std::to_string(Settings.hudcolors.ccheartsprimg);
+        Conf[HUDColorSection]["cc_heartsprimb"] = std::to_string(Settings.hudcolors.ccheartsprimb);
+        Conf[HUDColorSection]["cc_ddheartsprimr"] = std::to_string(Settings.hudcolors.ddccheartsprimr);
+        Conf[HUDColorSection]["cc_ddheartsprimg"] = std::to_string(Settings.hudcolors.ddccheartsprimg);
+        Conf[HUDColorSection]["cc_ddheartsprimb"] = std::to_string(Settings.hudcolors.ddccheartsprimb);
+        Conf[HUDColorSection]["cc_abtnprimr"] = std::to_string(Settings.hudcolors.ccabtnprimr);
+        Conf[HUDColorSection]["cc_abtnprimg"] = std::to_string(Settings.hudcolors.ccabtnprimg);
+        Conf[HUDColorSection]["cc_abtnprimb"] = std::to_string(Settings.hudcolors.ccabtnprimb);
+        Conf[HUDColorSection]["cc_bbtnprimr"] = std::to_string(Settings.hudcolors.ccbbtnprimr);
+        Conf[HUDColorSection]["cc_bbtnprimg"] = std::to_string(Settings.hudcolors.ccbbtnprimg);
+        Conf[HUDColorSection]["cc_bbtnprimb"] = std::to_string(Settings.hudcolors.ccbbtnprimb);
+        Conf[HUDColorSection]["cc_cbtnprimr"] = std::to_string(Settings.hudcolors.cccbtnprimr);
+        Conf[HUDColorSection]["cc_cbtnprimg"] = std::to_string(Settings.hudcolors.cccbtnprimg);
+        Conf[HUDColorSection]["cc_cbtnprimb"] = std::to_string(Settings.hudcolors.cccbtnprimb);
+        Conf[HUDColorSection]["cc_startbtnprimr"] = std::to_string(Settings.hudcolors.ccstartbtnprimr);
+        Conf[HUDColorSection]["cc_startbtnprimg"] = std::to_string(Settings.hudcolors.ccstartbtnprimg);
+        Conf[HUDColorSection]["cc_startbtnprimb"] = std::to_string(Settings.hudcolors.ccstartbtnprimb);
+        Conf[HUDColorSection]["cc_magicborderprimr"] = std::to_string(Settings.hudcolors.ccmagicborderprimr);
+        Conf[HUDColorSection]["cc_magicborderprimg"] = std::to_string(Settings.hudcolors.ccmagicborderprimg);
+        Conf[HUDColorSection]["cc_magicborderprimb"] = std::to_string(Settings.hudcolors.ccmagicborderprimb);
+        Conf[HUDColorSection]["cc_magicprimr"] = std::to_string(Settings.hudcolors.ccmagicprimr);
+        Conf[HUDColorSection]["cc_magicprimg"] = std::to_string(Settings.hudcolors.ccmagicprimg);
+        Conf[HUDColorSection]["cc_magicprimb"] = std::to_string(Settings.hudcolors.ccmagicprimb);
+        Conf[HUDColorSection]["cc_magicuseprimr"] = std::to_string(Settings.hudcolors.ccmagicuseprimr);
+        Conf[HUDColorSection]["cc_magicuseprimg"] = std::to_string(Settings.hudcolors.ccmagicuseprimg);
+        Conf[HUDColorSection]["cc_magicuseprimb"] = std::to_string(Settings.hudcolors.ccmagicuseprimb);
+        Conf[HUDColorSection]["cc_minimapprimr"] = std::to_string(Settings.hudcolors.ccminimapprimr);
+        Conf[HUDColorSection]["cc_minimapprimg"] = std::to_string(Settings.hudcolors.ccminimapprimg);
+        Conf[HUDColorSection]["cc_minimapprimb"] = std::to_string(Settings.hudcolors.ccminimapprimb);
+        Conf[HUDColorSection]["cc_rupeeprimr"] = std::to_string(Settings.hudcolors.ccrupeeprimr);
+        Conf[HUDColorSection]["cc_rupeeprimg"] = std::to_string(Settings.hudcolors.ccrupeeprimg);
+        Conf[HUDColorSection]["cc_rupeeprimb"] = std::to_string(Settings.hudcolors.ccrupeeprimb);
 
         //Languages
         Conf[LanguagesSection]["set_eng"] = std::to_string(Settings.languages.set_eng);

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -7,6 +7,7 @@ struct SoHConfigType {
         bool n64mode = false;
         bool menu_bar = false;
         bool soh_sink = true;
+        bool buildinfos = false;
     } debug;
 
     // Audio
@@ -20,7 +21,8 @@ struct SoHConfigType {
 
     // Enhancements
     struct {
-        bool fast_text = false;
+        int text_speed = 1;
+        bool skip_text = false;
         bool disable_lod = false;
         bool animated_pause_menu = false;
         bool minimal_ui = false;

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -26,7 +26,6 @@ struct SoHConfigType {
         bool minimal_ui = false;
         bool reworked_controls = false;
         bool newdrops = false;
-        bool n64color = false;
         bool dynamic_wallet_icon = false;
         bool mm_bunny_hood = false;
         bool uniform_lr = true;
@@ -63,6 +62,62 @@ struct SoHConfigType {
         bool freeze_time = false;
     } cheats;
 
+    // Graphics
+    struct {
+        bool show = false;
+    } graphics;
+
+    // HUD Colors
+    struct {
+        bool n64_colors = true;
+        bool gc_colors = false;
+        bool custom_colors = false;
+        //hearts colors
+        int ccheartsprimr = 255;
+        int ccheartsprimg = 70;
+        int ccheartsprimb = 50;
+        //hearts double defense colors
+        int ddccheartsprimr = 255;
+        int ddccheartsprimg = 255;
+        int ddccheartsprimb = 255;
+        //A Button Main colors
+        int ccabtnprimr = 90;
+        int ccabtnprimg = 90;
+        int ccabtnprimb = 255;
+        //B Button Main colors
+        int ccbbtnprimr = 0;
+        int ccbbtnprimg = 150;
+        int ccbbtnprimb = 0;
+        //C Button Main colors
+        int cccbtnprimr = 255;
+        int cccbtnprimg = 160;
+        int cccbtnprimb = 0;
+        //Start Button Main colors
+        int ccstartbtnprimr = 200;
+        int ccstartbtnprimg = 0;
+        int ccstartbtnprimb = 0;
+        //Magic Border colors
+        int ccmagicborderprimr = 255;
+        int ccmagicborderprimg = 255;
+        int ccmagicborderprimb = 255;
+        //Magic Main colors
+        int ccmagicprimr = 10;
+        int ccmagicprimg = 255;
+        int ccmagicprimb = 10;
+        //Magic Being used colors
+        int ccmagicuseprimr = 250;
+        int ccmagicuseprimg = 250;
+        int ccmagicuseprimb = 0;
+        //Minimap
+        int ccminimapprimr = 10;
+        int ccminimapprimg = 10;
+        int ccminimapprimb = 180;
+        //Rupee icon
+        int ccrupeeprimr = 10;
+        int ccrupeeprimg = 220;
+        int ccrupeeprimb = 10;
+    } hudcolors;
+
     // Languages
     struct {
         bool set_eng = true;
@@ -84,6 +139,7 @@ enum SeqPlayers {
 #define CONTROLLER_SECTION "CONTROLLER SECTION"
 #define ENHANCEMENTS_SECTION "ENHANCEMENT SETTINGS"
 #define CHEATS_SECTION "CHEATS SETTINGS"
+#define HUDCOLOR_SECTION "HUD COLORS SETTINGS"
 #define LANGUAGES_SECTION "LANGUAGES SETTINGS"
 
 namespace Game {

--- a/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_direct3d11.cpp
@@ -37,9 +37,8 @@ namespace {
 
 struct PerFrameCB {
     uint32_t noise_frame;
-    float noise_scale_x;
-    float noise_scale_y;
-    uint32_t padding;
+    float noise_scale;
+    uint32_t padding[2]; // constant buffers must be multiples of 16 bytes in size
 };
 
 struct PerDrawCB {
@@ -51,12 +50,12 @@ struct PerDrawCB {
     } textures[2];
 };
 
-struct CoordCB {
-    float x, y;
-    float padding[2]; // structure size must be multiple of 16
+struct Coord {
+    int x, y;
 };
 
 struct TextureData {
+    ComPtr<ID3D11Texture2D> texture;
     ComPtr<ID3D11ShaderResourceView> resource_view;
     ComPtr<ID3D11SamplerState> sampler_state;
     uint32_t width;
@@ -64,10 +63,13 @@ struct TextureData {
     bool linear_filtering;
 };
 
-struct FramebufferData {
+struct Framebuffer {
     ComPtr<ID3D11RenderTargetView> render_target_view;
     ComPtr<ID3D11DepthStencilView> depth_stencil_view;
+    ComPtr<ID3D11ShaderResourceView> depth_stencil_srv;
     uint32_t texture_id;
+    bool has_depth_buffer;
+    uint32_t msaa_level;
 };
 
 struct ShaderProgramD3D11 {
@@ -91,33 +93,29 @@ static struct {
     pD3DCompile D3DCompile;
 
     D3D_FEATURE_LEVEL feature_level;
+    uint32_t msaa_num_quality_levels[D3D11_MAX_MULTISAMPLE_SAMPLE_COUNT];
 
     ComPtr<ID3D11Device> device;
     ComPtr<IDXGISwapChain1> swap_chain;
     ComPtr<ID3D11DeviceContext> context;
-    ComPtr<ID3D11RenderTargetView> backbuffer_view;
-    ComPtr<ID3D11DepthStencilView> depth_stencil_view;
-    ComPtr<ID3D11ShaderResourceView> depth_stencil_srv;
     ComPtr<ID3D11RasterizerState> rasterizer_state;
     ComPtr<ID3D11DepthStencilState> depth_stencil_state;
     ComPtr<ID3D11Buffer> vertex_buffer;
     ComPtr<ID3D11Buffer> per_frame_cb;
     ComPtr<ID3D11Buffer> per_draw_cb;
-    ComPtr<ID3D11Texture2D> depth_stencil_texture;
-    ComPtr<ID3D11Texture2D> depth_stencil_copy_texture;
     ComPtr<ID3D11Buffer> coord_buffer;
+    ComPtr<ID3D11ShaderResourceView> coord_buffer_srv;
     ComPtr<ID3D11Buffer> depth_value_output_buffer;
     ComPtr<ID3D11Buffer> depth_value_output_buffer_copy;
     ComPtr<ID3D11UnorderedAccessView> depth_value_output_uav;
-    ComPtr<ID3D11SamplerState> depth_value_sampler;
     ComPtr<ID3D11ComputeShader> compute_shader;
-    bool copied_depth_buffer;
+    ComPtr<ID3D11ComputeShader> compute_shader_msaa;
+    ComPtr<ID3DBlob> compute_shader_msaa_blob;
+    size_t coord_buffer_size;
 
 #if DEBUG_D3D
     ComPtr<ID3D11Debug> debug;
 #endif
-
-    DXGI_SAMPLE_DESC sample_description;
 
     PerFrameCB per_frame_cb_data;
     PerDrawCB per_draw_cb_data;
@@ -128,18 +126,19 @@ static struct {
     int current_tile;
     uint32_t current_texture_ids[2];
 
-    std::vector<FramebufferData> framebuffers;
+    std::vector<Framebuffer> framebuffers;
 
     // Current state
 
     struct ShaderProgramD3D11 *shader_program;
 
-    uint32_t current_width, current_height;
     uint32_t render_target_height;
+    int current_framebuffer;
 
     int8_t depth_test;
     int8_t depth_mask;
     int8_t zmode_decal;
+
 
     // Previous states (to prevent setting states needlessly)
 
@@ -156,7 +155,9 @@ static struct {
 
 static LARGE_INTEGER last_time, accumulated_time, frequency;
 
-void create_depth_stencil_objects(uint32_t width, uint32_t height, ID3D11Texture2D **texture, ID3D11DepthStencilView **view, ID3D11ShaderResourceView **srv) {
+int gfx_d3d11_create_framebuffer(void);
+
+void create_depth_stencil_objects(uint32_t width, uint32_t height, uint32_t msaa_count, ID3D11DepthStencilView **view, ID3D11ShaderResourceView **srv) {
     D3D11_TEXTURE2D_DESC texture_desc;
     texture_desc.Width = width;
     texture_desc.Height = height;
@@ -164,91 +165,40 @@ void create_depth_stencil_objects(uint32_t width, uint32_t height, ID3D11Texture
     texture_desc.ArraySize = 1;
     texture_desc.Format = d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 ?
         DXGI_FORMAT_R32_TYPELESS : DXGI_FORMAT_R24G8_TYPELESS;
-    texture_desc.SampleDesc.Count = 1;
+    texture_desc.SampleDesc.Count = msaa_count;
     texture_desc.SampleDesc.Quality = 0;
     texture_desc.Usage = D3D11_USAGE_DEFAULT;
     texture_desc.BindFlags = D3D11_BIND_DEPTH_STENCIL | (srv != nullptr ? D3D11_BIND_SHADER_RESOURCE : 0);
     texture_desc.CPUAccessFlags = 0;
     texture_desc.MiscFlags = 0;
 
-    ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, nullptr, texture));
+    ComPtr<ID3D11Texture2D> texture;
+    ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, nullptr, texture.GetAddressOf()));
 
     D3D11_DEPTH_STENCIL_VIEW_DESC view_desc;
     view_desc.Format = d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 ?
         DXGI_FORMAT_D32_FLOAT : DXGI_FORMAT_D24_UNORM_S8_UINT;
-    view_desc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
     view_desc.Flags = 0;
-    view_desc.Texture2D.MipSlice = 0;
+    if (msaa_count > 1) {
+        view_desc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DMS;
+        view_desc.Texture2DMS.UnusedField_NothingToDefine = 0;
+    } else {
+        view_desc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+        view_desc.Texture2D.MipSlice = 0;
+    }
 
-    ThrowIfFailed(d3d.device->CreateDepthStencilView(*texture, &view_desc, view));
+    ThrowIfFailed(d3d.device->CreateDepthStencilView(texture.Get(), &view_desc, view));
 
     if (srv != nullptr) {
         D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc;
         srv_desc.Format = d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 ?
             DXGI_FORMAT_R32_FLOAT : DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
-        srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+        srv_desc.ViewDimension = msaa_count > 1 ? D3D11_SRV_DIMENSION_TEXTURE2DMS : D3D11_SRV_DIMENSION_TEXTURE2D;
         srv_desc.Texture2D.MostDetailedMip = 0;
         srv_desc.Texture2D.MipLevels = -1;
 
-        ThrowIfFailed(d3d.device->CreateShaderResourceView(*texture, &srv_desc, srv));
+        ThrowIfFailed(d3d.device->CreateShaderResourceView(texture.Get(), &srv_desc, srv));
     }
-}
-
-static void create_render_target_views(bool is_resize) {
-    DXGI_SWAP_CHAIN_DESC1 desc1;
-
-    if (is_resize) {
-        // Release previous stuff (if any)
-
-        d3d.backbuffer_view.Reset();
-        d3d.depth_stencil_texture.Reset();
-        d3d.depth_stencil_view.Reset();
-        d3d.depth_stencil_srv.Reset();
-        d3d.depth_stencil_copy_texture.Reset();
-
-        // Resize swap chain buffers
-
-        ThrowIfFailed(d3d.swap_chain->GetDesc1(&desc1));
-        ThrowIfFailed(d3d.swap_chain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, desc1.Flags),
-                      gfx_dxgi_get_h_wnd(), "Failed to resize IDXGISwapChain buffers.");
-    }
-
-    // Get new size
-
-    ThrowIfFailed(d3d.swap_chain->GetDesc1(&desc1));
-
-    // Create back buffer
-
-    ComPtr<ID3D11Texture2D> backbuffer_texture;
-    ThrowIfFailed(d3d.swap_chain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID *) backbuffer_texture.GetAddressOf()),
-                  gfx_dxgi_get_h_wnd(), "Failed to get backbuffer from IDXGISwapChain.");
-
-    ThrowIfFailed(d3d.device->CreateRenderTargetView(backbuffer_texture.Get(), nullptr, d3d.backbuffer_view.GetAddressOf()),
-                  gfx_dxgi_get_h_wnd(), "Failed to create render target view.");
-
-    // Create depth buffer
-    create_depth_stencil_objects(desc1.Width, desc1.Height, d3d.depth_stencil_texture.GetAddressOf(), d3d.depth_stencil_view.GetAddressOf(), d3d.depth_stencil_srv.GetAddressOf());
-
-    // Create texture that can be used to retrieve depth value
-
-    D3D11_TEXTURE2D_DESC depth_texture = {};
-    depth_texture.Width = desc1.Width;
-    depth_texture.Height = desc1.Height;
-    depth_texture.MipLevels = 1;
-    depth_texture.ArraySize = 1;
-    depth_texture.Format = DXGI_FORMAT_D32_FLOAT;
-    depth_texture.SampleDesc.Count = 1;
-    depth_texture.SampleDesc.Quality = 0;
-    depth_texture.Usage = D3D11_USAGE_STAGING;
-    depth_texture.BindFlags = 0;
-    depth_texture.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    depth_texture.MiscFlags = 0;
-    ThrowIfFailed(d3d.device->CreateTexture2D(&depth_texture, nullptr, d3d.depth_stencil_copy_texture.GetAddressOf()));
-
-    // Save resolution
-
-    d3d.current_width = desc1.Width;
-    d3d.current_height = desc1.Height;
 }
 
 static void gfx_d3d11_init(void) {
@@ -300,11 +250,6 @@ static void gfx_d3d11_init(void) {
         }
     });
 
-    // Sample description to be used in back buffer and depth buffer
-
-    d3d.sample_description.Count = 1;
-    d3d.sample_description.Quality = 0;
-
     // Create the swap chain
     d3d.swap_chain = gfx_dxgi_create_swap_chain(d3d.device.Get());
 
@@ -315,9 +260,19 @@ static void gfx_d3d11_init(void) {
                   gfx_dxgi_get_h_wnd(), "Failed to get ID3D11Debug device.");
 #endif
 
-    // Create views
+    // Create the default framebuffer which represents the window
+    Framebuffer& fb = d3d.framebuffers[gfx_d3d11_create_framebuffer()];
 
-    create_render_target_views(false);
+    // Check the size of the window
+    DXGI_SWAP_CHAIN_DESC1 swap_chain_desc;
+    ThrowIfFailed(d3d.swap_chain->GetDesc1(&swap_chain_desc));
+    d3d.textures[fb.texture_id].width = swap_chain_desc.Width;
+    d3d.textures[fb.texture_id].height = swap_chain_desc.Height;
+    fb.msaa_level = 1;
+
+    for (uint32_t sample_count = 1; sample_count <= D3D11_MAX_MULTISAMPLE_SAMPLE_COUNT; sample_count++) {
+        ThrowIfFailed(d3d.device->CheckMultisampleQualityLevels(DXGI_FORMAT_R8G8B8A8_UNORM, sample_count, &d3d.msaa_num_quality_levels[sample_count - 1]));
+    }
 
     // Create main vertex buffer
 
@@ -364,59 +319,26 @@ static void gfx_d3d11_init(void) {
 
     // Create compute shader that can be used to retrieve depth buffer values
 
-    D3D11_BUFFER_DESC coord_cb_desc;
-    coord_cb_desc.Usage = D3D11_USAGE_DYNAMIC;
-    coord_cb_desc.ByteWidth = sizeof(CoordCB);
-    coord_cb_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-    coord_cb_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-    coord_cb_desc.MiscFlags = 0;
-    coord_cb_desc.StructureByteStride = 0;
-
-    ThrowIfFailed(d3d.device->CreateBuffer(&coord_cb_desc, nullptr, d3d.coord_buffer.GetAddressOf()));
-
-    D3D11_SAMPLER_DESC sampler_desc = {};
-    sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
-    sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sampler_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-    sampler_desc.MinLOD = 0;
-    sampler_desc.MaxLOD = D3D11_FLOAT32_MAX;
-    ThrowIfFailed(d3d.device->CreateSamplerState(&sampler_desc, d3d.depth_value_sampler.GetAddressOf()));
-
-    D3D11_BUFFER_DESC output_buffer_desc;
-    output_buffer_desc.Usage = D3D11_USAGE_DEFAULT;
-    output_buffer_desc.ByteWidth = sizeof(float);
-    output_buffer_desc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
-    output_buffer_desc.CPUAccessFlags = 0;
-    output_buffer_desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
-    output_buffer_desc.StructureByteStride = sizeof(float);
-    ThrowIfFailed(d3d.device->CreateBuffer(&output_buffer_desc, nullptr, d3d.depth_value_output_buffer.GetAddressOf()));
-
-    D3D11_UNORDERED_ACCESS_VIEW_DESC output_buffer_uav_desc;
-    output_buffer_uav_desc.Format = DXGI_FORMAT_UNKNOWN;
-    output_buffer_uav_desc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
-    output_buffer_uav_desc.Buffer.FirstElement = 0;
-    output_buffer_uav_desc.Buffer.NumElements = 1;
-    output_buffer_uav_desc.Buffer.Flags = 0;
-    ThrowIfFailed(d3d.device->CreateUnorderedAccessView(d3d.depth_value_output_buffer.Get(), &output_buffer_uav_desc, d3d.depth_value_output_uav.GetAddressOf()));
-
-    output_buffer_desc.Usage = D3D11_USAGE_STAGING;
-    output_buffer_desc.BindFlags = 0;
-    output_buffer_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    ThrowIfFailed(d3d.device->CreateBuffer(&output_buffer_desc, nullptr, d3d.depth_value_output_buffer_copy.GetAddressOf()));
-
     const char* shader_source = R"(
 sampler my_sampler : register(s0);
 Texture2D<float> tex : register(t0);
-cbuffer coordCB : register(b0) {
-    float2 coord;
+StructuredBuffer<int2> coord : register(t1);
+RWStructuredBuffer<float> output : register(u0);
+[numthreads(1, 1, 1)]
+void CSMain(uint3 DTid : SV_DispatchThreadID) {
+    output[DTid.x] = tex.Load(int3(coord[DTid.x], 0));
 }
+)";
 
+const char* shader_source_msaa = R"(
+sampler my_sampler : register(s0);
+Texture2DMS<float, 2> tex : register(t0);
+StructuredBuffer<int2> coord : register(t1);
 RWStructuredBuffer<float> output : register(u0);
 
 [numthreads(1, 1, 1)]
 void CSMain(uint3 DTid : SV_DispatchThreadID) {
-    output[0] = tex.SampleLevel(my_sampler, coord, 0);
+    output[DTid.x] = tex.Load(coord[DTid.x], 0);
 }
 )";
 #if DEBUG_D3D
@@ -426,7 +348,9 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
 #endif
 
     ComPtr<ID3DBlob> cs, error_blob;
-    HRESULT hr = d3d.D3DCompile(shader_source, strlen(shader_source), nullptr, nullptr, nullptr, "CSMain", "cs_4_0", compile_flags, 0, cs.GetAddressOf(), error_blob.GetAddressOf());
+    HRESULT hr;
+
+    hr = d3d.D3DCompile(shader_source, strlen(shader_source), nullptr, nullptr, nullptr, "CSMain", "cs_4_0", compile_flags, 0, cs.GetAddressOf(), error_blob.GetAddressOf());
 
     if (FAILED(hr)) {
         char* err = (char*)error_blob->GetBufferPointer();
@@ -435,6 +359,14 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
     }
 
     ThrowIfFailed(d3d.device->CreateComputeShader(cs->GetBufferPointer(), cs->GetBufferSize(), nullptr, d3d.compute_shader.GetAddressOf()));
+
+    hr = d3d.D3DCompile(shader_source_msaa, strlen(shader_source_msaa), nullptr, nullptr, nullptr, "CSMain", "cs_4_1", compile_flags, 0, d3d.compute_shader_msaa_blob.GetAddressOf(), error_blob.ReleaseAndGetAddressOf());
+
+    if (FAILED(hr)) {
+        char* err = (char*)error_blob->GetBufferPointer();
+        MessageBoxA(gfx_dxgi_get_h_wnd(), err, "Error", MB_OK | MB_ICONERROR);
+        throw hr;
+    }
 
     // Create ImGui
 
@@ -445,8 +377,8 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
 }
 
 
-static bool gfx_d3d11_z_is_from_0_to_1(void) {
-    return true;
+static struct GfxClipParameters gfx_d3d11_get_clip_parameters(void) {
+    return { true, false };
 }
 
 static void gfx_d3d11_unload_shader(struct ShaderProgram *old_prg) {
@@ -528,8 +460,8 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(uint64_t shade
 
     if (cc_features.opt_alpha) {
         blend_desc.RenderTarget[0].BlendEnable = true;
-        blend_desc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
-        blend_desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+        blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ZERO;
+        blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE; // We initially clear alpha to 1.0f and want to keep it at 1.0f
         blend_desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
         blend_desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
         blend_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
@@ -592,6 +524,10 @@ static D3D11_TEXTURE_ADDRESS_MODE gfx_cm_to_d3d11(uint32_t val) {
 static void gfx_d3d11_upload_texture(const uint8_t *rgba32_buf, uint32_t width, uint32_t height) {
     // Create texture
 
+    TextureData *texture_data = &d3d.textures[d3d.current_texture_ids[d3d.current_tile]];
+    texture_data->width = width;
+    texture_data->height = height;
+
     D3D11_TEXTURE2D_DESC texture_desc;
     ZeroMemory(&texture_desc, sizeof(D3D11_TEXTURE2D_DESC));
 
@@ -612,12 +548,7 @@ static void gfx_d3d11_upload_texture(const uint8_t *rgba32_buf, uint32_t width, 
     resource_data.SysMemPitch = width * 4;
     resource_data.SysMemSlicePitch = resource_data.SysMemPitch * height;
 
-    ComPtr<ID3D11Texture2D> texture;
-    ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, &resource_data, texture.GetAddressOf()));
-
-    TextureData *texture_data = &d3d.textures[d3d.current_texture_ids[d3d.current_tile]];
-    texture_data->width = width;
-    texture_data->height = height;
+    ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, &resource_data, texture_data->texture.ReleaseAndGetAddressOf()));
 
     // Create shader resource view from texture
 
@@ -626,7 +557,7 @@ static void gfx_d3d11_upload_texture(const uint8_t *rgba32_buf, uint32_t width, 
         texture_data->resource_view.Reset();
     }
 
-    ThrowIfFailed(d3d.device->CreateShaderResourceView(texture.Get(), nullptr, texture_data->resource_view.GetAddressOf()));
+    ThrowIfFailed(d3d.device->CreateShaderResourceView(texture_data->texture.Get(), nullptr, texture_data->resource_view.ReleaseAndGetAddressOf()));
 }
 
 static void gfx_d3d11_set_sampler_parameters(int tile, bool linear_filter, uint32_t cms, uint32_t cmt) {
@@ -803,19 +734,10 @@ static void gfx_d3d11_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t
 }
 
 static void gfx_d3d11_on_resize(void) {
-    create_render_target_views(true);
+    //create_render_target_views(true);
 }
 
 static void gfx_d3d11_start_frame(void) {
-    // Set render targets
-
-    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), d3d.depth_stencil_view.Get());
-
-    // Clear render targets
-
-    const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    d3d.context->ClearRenderTargetView(d3d.backbuffer_view.Get(), clearColor);
-    d3d.context->ClearDepthStencilView(d3d.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
 
     // Set per-frame constant buffer
 
@@ -824,22 +746,9 @@ static void gfx_d3d11_start_frame(void) {
         // No high values, as noise starts to look ugly
         d3d.per_frame_cb_data.noise_frame = 0;
     }
-    float aspect_ratio = (float) d3d.current_width / (float) d3d.current_height;
-    d3d.render_target_height = d3d.current_height;
-    d3d.per_frame_cb_data.noise_scale_x = 120 * aspect_ratio; // 120 = N64 height resolution (240) / 2
-    d3d.per_frame_cb_data.noise_scale_y = 120;
-
-    D3D11_MAPPED_SUBRESOURCE ms;
-    ZeroMemory(&ms, sizeof(D3D11_MAPPED_SUBRESOURCE));
-    d3d.context->Map(d3d.per_frame_cb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms);
-    memcpy(ms.pData, &d3d.per_frame_cb_data, sizeof(PerFrameCB));
-    d3d.context->Unmap(d3d.per_frame_cb.Get(), 0);
-
-    d3d.copied_depth_buffer = false;
 }
 
 static void gfx_d3d11_end_frame(void) {
-    SohImGui::Draw();
     d3d.context->Flush();
 }
 
@@ -847,43 +756,13 @@ static void gfx_d3d11_finish_render(void) {
     d3d.context->Flush();
 }
 
-void gfx_d3d11_resize_framebuffer(int fb, uint32_t width, uint32_t height) {
-    FramebufferData& fd = d3d.framebuffers[fb];
-    TextureData& td = d3d.textures[fd.texture_id];
-
-    ComPtr<ID3D11Texture2D> texture, depth_stencil_texture;
-
-    D3D11_TEXTURE2D_DESC texture_desc;
-    texture_desc.Width = width;
-    texture_desc.Height = height;
-    texture_desc.Usage = D3D11_USAGE_DEFAULT;
-    texture_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
-    texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    texture_desc.CPUAccessFlags = 0;
-    texture_desc.MiscFlags = 0;
-    texture_desc.ArraySize = 1;
-    texture_desc.MipLevels = 1;
-    texture_desc.SampleDesc.Count = 1;
-    texture_desc.SampleDesc.Quality = 0;
-
-    ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, nullptr, texture.GetAddressOf()));
-    create_depth_stencil_objects(width, height, depth_stencil_texture.GetAddressOf(), fd.depth_stencil_view.ReleaseAndGetAddressOf(), nullptr);
-    ThrowIfFailed(d3d.device->CreateRenderTargetView(texture.Get(), nullptr, fd.render_target_view.ReleaseAndGetAddressOf()));
-    ThrowIfFailed(d3d.device->CreateShaderResourceView(texture.Get(), nullptr, td.resource_view.ReleaseAndGetAddressOf()));
-
-    td.width = width;
-    td.height = height;
-}
-
-int gfx_d3d11_create_framebuffer(uint32_t width, uint32_t height) {
+int gfx_d3d11_create_framebuffer(void) {
     uint32_t texture_id = gfx_d3d11_new_texture();
     TextureData& t = d3d.textures[texture_id];
-    t.width = width;
-    t.height = height;
 
     size_t index = d3d.framebuffers.size();
     d3d.framebuffers.resize(d3d.framebuffers.size() + 1);
-    FramebufferData& data = d3d.framebuffers.back();
+    Framebuffer& data = d3d.framebuffers.back();
     data.texture_id = texture_id;
 
     uint32_t tile = 0;
@@ -892,24 +771,108 @@ int gfx_d3d11_create_framebuffer(uint32_t width, uint32_t height) {
     gfx_d3d11_set_sampler_parameters(0, true, G_TX_WRAP, G_TX_WRAP);
     d3d.current_texture_ids[tile] = saved;
 
-    gfx_d3d11_resize_framebuffer(index, width, height);
-
     return (int)index;
 }
 
-void gfx_d3d11_set_framebuffer(int fb) {
-    d3d.render_target_height = d3d.textures[d3d.framebuffers[fb].texture_id].height;
+static void gfx_d3d11_update_framebuffer_parameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level, bool opengl_invert_y, bool render_target, bool has_depth_buffer, bool can_extract_depth) {
+    Framebuffer& fb = d3d.framebuffers[fb_id];
+    TextureData& tex = d3d.textures[fb.texture_id];
 
-    d3d.context->OMSetRenderTargets(1, d3d.framebuffers[fb].render_target_view.GetAddressOf(), d3d.framebuffers[fb].depth_stencil_view.Get());
+    width = max(width, 1U);
+    height = max(height, 1U);
+    while (msaa_level > 1 && d3d.msaa_num_quality_levels[msaa_level - 1] == 0) {
+        --msaa_level;
+    }
 
-    const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    d3d.context->ClearRenderTargetView(d3d.framebuffers[fb].render_target_view.Get(), clearColor);
-    d3d.context->ClearDepthStencilView(d3d.framebuffers[fb].depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+    bool diff = tex.width != width || tex.height != height || fb.msaa_level != msaa_level;
+
+    if (diff || (fb.render_target_view.Get() != nullptr) != render_target) {
+        if (fb_id != 0) {
+            D3D11_TEXTURE2D_DESC texture_desc;
+            texture_desc.Width = width;
+            texture_desc.Height = height;
+            texture_desc.Usage = D3D11_USAGE_DEFAULT;
+            texture_desc.BindFlags = (msaa_level <= 1 ? D3D11_BIND_SHADER_RESOURCE : 0) | (render_target ? D3D11_BIND_RENDER_TARGET : 0);
+            texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            texture_desc.CPUAccessFlags = 0;
+            texture_desc.MiscFlags = 0;
+            texture_desc.ArraySize = 1;
+            texture_desc.MipLevels = 1;
+            texture_desc.SampleDesc.Count = msaa_level;
+            texture_desc.SampleDesc.Quality = 0;
+
+            ThrowIfFailed(d3d.device->CreateTexture2D(&texture_desc, nullptr, tex.texture.ReleaseAndGetAddressOf()));
+
+            if (msaa_level <= 1) {
+                ThrowIfFailed(d3d.device->CreateShaderResourceView(tex.texture.Get(), nullptr, tex.resource_view.ReleaseAndGetAddressOf()));
+            }
+        } else if (diff) {
+            DXGI_SWAP_CHAIN_DESC1 desc1;
+            ThrowIfFailed(d3d.swap_chain->GetDesc1(&desc1));
+            if (desc1.Width != width || desc1.Height != height) {
+                fb.render_target_view.Reset();
+                tex.texture.Reset();
+                ThrowIfFailed(d3d.swap_chain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, desc1.Flags));
+            }
+            ThrowIfFailed(d3d.swap_chain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID *)tex.texture.ReleaseAndGetAddressOf()));
+        }
+        if (render_target) {
+            ThrowIfFailed(d3d.device->CreateRenderTargetView(tex.texture.Get(), nullptr, fb.render_target_view.ReleaseAndGetAddressOf()));
+        }
+
+        tex.width = width;
+        tex.height = height;
+    }
+    if (has_depth_buffer && (diff || !fb.has_depth_buffer || (fb.depth_stencil_srv.Get() != nullptr) != can_extract_depth)) {
+        fb.depth_stencil_srv.Reset();
+        create_depth_stencil_objects(width, height, msaa_level, fb.depth_stencil_view.ReleaseAndGetAddressOf(), can_extract_depth ? fb.depth_stencil_srv.GetAddressOf() : nullptr);
+    }
+    if (!has_depth_buffer) {
+        fb.depth_stencil_view.Reset();
+        fb.depth_stencil_srv.Reset();
+    }
+
+    fb.has_depth_buffer = has_depth_buffer;
+    fb.msaa_level = msaa_level;
 }
 
-void gfx_d3d11_reset_framebuffer(void) {
-    d3d.render_target_height = d3d.current_height;
-    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), d3d.depth_stencil_view.Get());
+void gfx_d3d11_start_draw_to_framebuffer(int fb_id, float noise_scale) {
+    Framebuffer& fb = d3d.framebuffers[fb_id];
+    d3d.render_target_height = d3d.textures[fb.texture_id].height;
+
+    d3d.context->OMSetRenderTargets(1, fb.render_target_view.GetAddressOf(), fb.has_depth_buffer ? fb.depth_stencil_view.Get() : nullptr);
+
+    d3d.current_framebuffer = fb_id;
+
+    if (noise_scale != 0.0f) {
+        d3d.per_frame_cb_data.noise_scale = 1.0f / noise_scale;
+    }
+
+    D3D11_MAPPED_SUBRESOURCE ms;
+    ZeroMemory(&ms, sizeof(D3D11_MAPPED_SUBRESOURCE));
+    d3d.context->Map(d3d.per_frame_cb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms);
+    memcpy(ms.pData, &d3d.per_frame_cb_data, sizeof(PerFrameCB));
+    d3d.context->Unmap(d3d.per_frame_cb.Get(), 0);
+}
+
+void gfx_d3d11_clear_framebuffer(void) {
+    Framebuffer& fb = d3d.framebuffers[d3d.current_framebuffer];
+    const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
+    d3d.context->ClearRenderTargetView(fb.render_target_view.Get(), clearColor);
+    if (fb.has_depth_buffer) {
+        d3d.context->ClearDepthStencilView(fb.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+    }
+}
+
+void gfx_d3d11_resolve_msaa_color_buffer(int fb_id_target, int fb_id_source) {
+    Framebuffer& fb_dst = d3d.framebuffers[fb_id_target];
+    Framebuffer& fb_src = d3d.framebuffers[fb_id_source];
+
+    d3d.context->ResolveSubresource(d3d.textures[fb_dst.texture_id].texture.Get(), 0, d3d.textures[fb_src.texture_id].texture.Get(), 0, DXGI_FORMAT_R8G8B8A8_UNORM);
+}
+
+void *gfx_d3d11_get_framebuffer_texture_id(int fb_id) {
+    return (void *)d3d.textures[d3d.framebuffers[fb_id].texture_id].resource_view.Get();
 }
 
 void gfx_d3d11_select_texture_fb(int fbID) {
@@ -917,62 +880,106 @@ void gfx_d3d11_select_texture_fb(int fbID) {
     gfx_d3d11_select_texture(tile, d3d.framebuffers[fbID].texture_id);
 }
 
-uint16_t gfx_d3d11_get_pixel_depth(float x, float y) {
+std::map<std::pair<float, float>, uint16_t> gfx_d3d11_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& coordinates) {
+    Framebuffer& fb = d3d.framebuffers[fb_id];
+    TextureData& td = d3d.textures[fb.texture_id];
+
+    if (coordinates.size() > d3d.coord_buffer_size) {
+        d3d.coord_buffer.Reset();
+        d3d.coord_buffer_srv.Reset();
+        d3d.depth_value_output_buffer.Reset();
+        d3d.depth_value_output_uav.Reset();
+        d3d.depth_value_output_buffer_copy.Reset();
+
+        D3D11_BUFFER_DESC coord_buf_desc;
+        coord_buf_desc.Usage = D3D11_USAGE_DYNAMIC;
+        coord_buf_desc.ByteWidth = sizeof(Coord) * coordinates.size();
+        coord_buf_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+        coord_buf_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+        coord_buf_desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        coord_buf_desc.StructureByteStride = sizeof(Coord);
+
+        ThrowIfFailed(d3d.device->CreateBuffer(&coord_buf_desc, nullptr, d3d.coord_buffer.GetAddressOf()));
+
+        D3D11_SHADER_RESOURCE_VIEW_DESC coord_buf_srv_desc;
+        coord_buf_srv_desc.Format = DXGI_FORMAT_UNKNOWN;
+        coord_buf_srv_desc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+        coord_buf_srv_desc.Buffer.FirstElement = 0;
+        coord_buf_srv_desc.Buffer.NumElements = coordinates.size();
+
+        ThrowIfFailed(d3d.device->CreateShaderResourceView(d3d.coord_buffer.Get(), &coord_buf_srv_desc, d3d.coord_buffer_srv.GetAddressOf()));
+
+        D3D11_BUFFER_DESC output_buffer_desc;
+        output_buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+        output_buffer_desc.ByteWidth = sizeof(float) * coordinates.size();
+        output_buffer_desc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
+        output_buffer_desc.CPUAccessFlags = 0;
+        output_buffer_desc.MiscFlags = D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        output_buffer_desc.StructureByteStride = sizeof(float);
+        ThrowIfFailed(d3d.device->CreateBuffer(&output_buffer_desc, nullptr, d3d.depth_value_output_buffer.GetAddressOf()));
+
+        D3D11_UNORDERED_ACCESS_VIEW_DESC output_buffer_uav_desc;
+        output_buffer_uav_desc.Format = DXGI_FORMAT_UNKNOWN;
+        output_buffer_uav_desc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+        output_buffer_uav_desc.Buffer.FirstElement = 0;
+        output_buffer_uav_desc.Buffer.NumElements = coordinates.size();
+        output_buffer_uav_desc.Buffer.Flags = 0;
+        ThrowIfFailed(d3d.device->CreateUnorderedAccessView(d3d.depth_value_output_buffer.Get(), &output_buffer_uav_desc, d3d.depth_value_output_uav.GetAddressOf()));
+
+        output_buffer_desc.Usage = D3D11_USAGE_STAGING;
+        output_buffer_desc.BindFlags = 0;
+        output_buffer_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        ThrowIfFailed(d3d.device->CreateBuffer(&output_buffer_desc, nullptr, d3d.depth_value_output_buffer_copy.GetAddressOf()));
+
+        d3d.coord_buffer_size = coordinates.size();
+    }
     D3D11_MAPPED_SUBRESOURCE ms;
 
+    if (fb.msaa_level > 1 && d3d.compute_shader_msaa.Get() == nullptr) {
+        ThrowIfFailed(d3d.device->CreateComputeShader(d3d.compute_shader_msaa_blob->GetBufferPointer(), d3d.compute_shader_msaa_blob->GetBufferSize(), nullptr, d3d.compute_shader_msaa.GetAddressOf()));
+    }
+
     // ImGui overwrites these values, so we cannot set them once at init
-    d3d.context->CSSetShader(d3d.compute_shader.Get(), nullptr, 0);
-    d3d.context->CSSetConstantBuffers(0, 1, d3d.coord_buffer.GetAddressOf());
-    d3d.context->CSSetSamplers(0, 1, d3d.depth_value_sampler.GetAddressOf());
+    d3d.context->CSSetShader(fb.msaa_level > 1 ? d3d.compute_shader_msaa.Get() : d3d.compute_shader.Get(), nullptr, 0);
     d3d.context->CSSetUnorderedAccessViews(0, 1, d3d.depth_value_output_uav.GetAddressOf(), nullptr);
 
     ThrowIfFailed(d3d.context->Map(d3d.coord_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms));
-    CoordCB* coord_cb = (CoordCB*)ms.pData;
-    coord_cb->x = x / d3d.current_width;
-    // We invert y because the game assumes OpenGL coordinates (bottom-left corner is origin), while DX's origin is top-left corner
-    coord_cb->y = 1 - y / d3d.current_height;
+    Coord *coord_cb = (Coord *)ms.pData;
+    {
+        size_t i = 0;
+        for (const auto& coord : coordinates) {
+            coord_cb[i].x = coord.first;
+            // We invert y because the gfx_pc assumes OpenGL coordinates (bottom-left corner is origin), while DX's origin is top-left corner
+            coord_cb[i].y = td.height - 1 - coord.second;
+            ++i;
+        }
+    }
     d3d.context->Unmap(d3d.coord_buffer.Get(), 0);
 
-    // The depth stencil texture can only have one mapping at a time, so temporarily unbind from the OM
-    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), nullptr);
-    d3d.context->CSSetShaderResources(0, 1, d3d.depth_stencil_srv.GetAddressOf());
+    // The depth stencil texture can only have one mapping at a time, so unbind from the OM
+    ID3D11RenderTargetView* null_arr1[1] = { nullptr };
+    d3d.context->OMSetRenderTargets(1, null_arr1, nullptr);
 
-    d3d.context->Dispatch(1, 1, 1);
+    ID3D11ShaderResourceView *srvs[] = { fb.depth_stencil_srv.Get(), d3d.coord_buffer_srv.Get() };
+    d3d.context->CSSetShaderResources(0, 2, srvs);
+
+    d3d.context->Dispatch(coordinates.size(), 1, 1);
 
     d3d.context->CopyResource(d3d.depth_value_output_buffer_copy.Get(), d3d.depth_value_output_buffer.Get());
     ThrowIfFailed(d3d.context->Map(d3d.depth_value_output_buffer_copy.Get(), 0, D3D11_MAP_READ, 0, &ms));
-    float res = *(float *)ms.pData;
-    d3d.context->Unmap(d3d.depth_value_output_buffer_copy.Get(), 0);
-
-    ID3D11ShaderResourceView *null_arr[1] = { nullptr };
-    d3d.context->CSSetShaderResources(0, 1, null_arr);
-    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), d3d.depth_stencil_view.Get());
-
-    return res * 65532.0f;
-}
-
-uint16_t gfx_d3d11_get_pixel_depth_old(float x, float y) {
-    // This approach, compared to using a compute shader, might have better performance on nvidia cards
-
-    if (!d3d.copied_depth_buffer) {
-        d3d.context->CopyResource(d3d.depth_stencil_copy_texture.Get(), d3d.depth_stencil_texture.Get());
-        d3d.copied_depth_buffer = true;
-    }
-
-    D3D11_MAPPED_SUBRESOURCE mapping_desc;
-    d3d.context->Map(d3d.depth_stencil_copy_texture.Get(), 0, D3D11_MAP_READ, 0, &mapping_desc);
-    float res = 0;
-    if (mapping_desc.pData != nullptr) {
-        float *addr = (float *)mapping_desc.pData;
-        uint32_t num_pixels = mapping_desc.DepthPitch / sizeof(float);
-        uint32_t width = mapping_desc.RowPitch / sizeof(float);
-        uint32_t height = width == 0 ? 0 : num_pixels / width;
-        if (x >= 0 && x < width && y >= 0 && y < height) {
-            res = addr[width * (height - 1 - (int)y) + (int)x];
+    std::map<std::pair<float, float>, uint16_t> res;
+    {
+        size_t i = 0;
+        for (const auto& coord : coordinates) {
+            res.emplace(coord, ((float *)ms.pData)[i++] * 65532.0f);
         }
     }
-    d3d.context->Unmap(d3d.depth_stencil_copy_texture.Get(), 0);
-    return res * 65532.0f;
+    d3d.context->Unmap(d3d.depth_value_output_buffer_copy.Get(), 0);
+
+    ID3D11ShaderResourceView *null_arr[2] = { nullptr, nullptr };
+    d3d.context->CSSetShaderResources(0, 2, null_arr);
+
+    return res;
 }
 
 } // namespace
@@ -982,7 +989,7 @@ void* SohImGui::GetTextureByID(int id) {
 }
 
 struct GfxRenderingAPI gfx_direct3d11_api = {
-    gfx_d3d11_z_is_from_0_to_1,
+    gfx_d3d11_get_clip_parameters,
     gfx_d3d11_unload_shader,
     gfx_d3d11_load_shader,
     gfx_d3d11_create_and_load_new_shader,
@@ -993,7 +1000,6 @@ struct GfxRenderingAPI gfx_direct3d11_api = {
     gfx_d3d11_upload_texture,
     gfx_d3d11_set_sampler_parameters,
     gfx_d3d11_set_depth_test_and_mask,
-    gfx_d3d11_get_pixel_depth,
     gfx_d3d11_set_zmode_decal,
     gfx_d3d11_set_viewport,
     gfx_d3d11_set_scissor,
@@ -1005,9 +1011,12 @@ struct GfxRenderingAPI gfx_direct3d11_api = {
     gfx_d3d11_end_frame,
     gfx_d3d11_finish_render,
     gfx_d3d11_create_framebuffer,
-    gfx_d3d11_resize_framebuffer,
-    gfx_d3d11_set_framebuffer,
-    gfx_d3d11_reset_framebuffer,
+    gfx_d3d11_update_framebuffer_parameters,
+    gfx_d3d11_start_draw_to_framebuffer,
+    gfx_d3d11_clear_framebuffer,
+    gfx_d3d11_resolve_msaa_color_buffer,
+    gfx_d3d11_get_pixel_depth,
+    gfx_d3d11_get_framebuffer_texture_id,
     gfx_d3d11_select_texture_fb,
     gfx_d3d11_delete_texture
 };

--- a/libultraship/libultraship/Lib/Fast3D/gfx_dxgi.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_dxgi.cpp
@@ -10,6 +10,8 @@
 #include <windows.h>
 #include <wrl/client.h>
 #include <dxgi1_3.h>
+#include <dxgi1_4.h>
+
 #include <versionhelpers.h>
 
 #include <shellscalingapi.h>
@@ -61,6 +63,7 @@ static struct {
     RECT last_window_rect;
     bool is_full_screen, last_maximized_state;
 
+    bool dxgi1_4;
     ComPtr<IDXGIFactory2> factory;
     ComPtr<IDXGISwapChain1> swap_chain;
     HANDLE waitable_object;
@@ -197,17 +200,6 @@ static void toggle_borderless_window_full_screen(bool enable, bool call_callback
     }
 }
 
-static void gfx_dxgi_on_resize(void) {
-    if (dxgi.swap_chain.Get() != nullptr) {
-        gfx_get_current_rendering_api()->on_resize();
-
-        DXGI_SWAP_CHAIN_DESC1 desc1;
-        ThrowIfFailed(dxgi.swap_chain->GetDesc1(&desc1));
-        dxgi.current_width = desc1.Width;
-        dxgi.current_height = desc1.Height;
-    }
-}
-
 static void onkeydown(WPARAM w_param, LPARAM l_param) {
     int key = ((l_param >> 16) & 0x1ff);
     if (dxgi.on_key_down != nullptr) {
@@ -227,7 +219,8 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
     SohImGui::Update(event_impl);
     switch (message) {
         case WM_SIZE:
-            gfx_dxgi_on_resize();
+            dxgi.current_width = (uint32_t)(l_param & 0xffff);
+            dxgi.current_height = (uint32_t)(l_param >> 16);
             break;
         case WM_DESTROY:
             exit(0);
@@ -572,7 +565,12 @@ void gfx_dxgi_create_factory_and_device(bool debug, int d3d_version, bool (*crea
     } else {
         ThrowIfFailed(dxgi.CreateDXGIFactory1(__uuidof(IDXGIFactory2), &dxgi.factory));
     }
-
+    {
+        ComPtr<IDXGIFactory4> factory4;
+        if (dxgi.factory->QueryInterface(__uuidof(IDXGIFactory4), &factory4) == S_OK) {
+            dxgi.dxgi1_4 = true;
+        }
+    }
     ComPtr<IDXGIAdapter1> adapter;
     for (UINT i = 0; dxgi.factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; i++) {
         DXGI_ADAPTER_DESC1 desc;
@@ -604,7 +602,9 @@ ComPtr<IDXGISwapChain1> gfx_dxgi_create_swap_chain(IUnknown *device) {
     swap_chain_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     swap_chain_desc.Scaling = win8 ? DXGI_SCALING_NONE : DXGI_SCALING_STRETCH;
-    swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL; // Apparently this was backported to Win 7 Platform Update
+    swap_chain_desc.SwapEffect = dxgi.dxgi1_4 ?
+        DXGI_SWAP_EFFECT_FLIP_DISCARD : // Introduced in DXGI 1.4 and Windows 10
+        DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL; // Apparently flip sequential was also backported to Win 7 Platform Update
     swap_chain_desc.Flags = dxgi_13 ? DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT : 0;
     swap_chain_desc.SampleDesc.Count = 1;
 

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -53,19 +53,32 @@ struct ShaderProgram {
     uint8_t num_attribs;
     bool used_noise;
     GLint frame_count_location;
-    GLint window_height_location;
+    GLint noise_scale_location;
+};
+
+struct Framebuffer {
+    uint32_t width, height;
+    bool has_depth_buffer;
+    uint32_t msaa_level;
+    bool invert_y;
+
+    GLuint fbo, clrbuf, clrbuf_msaa, rbo;
 };
 
 static map<pair<uint64_t, uint32_t>, struct ShaderProgram> shader_program_pool;
 static GLuint opengl_vbo;
-
-static uint32_t frame_count;
-static uint32_t current_height;
-static map<int, pair<GLuint, GLuint>> fb2tex;
 static bool current_depth_mask;
 
-static bool gfx_opengl_z_is_from_0_to_1(void) {
-    return false;
+static uint32_t frame_count;
+static vector<Framebuffer> framebuffers;
+static size_t current_framebuffer;
+static float current_noise_scale;
+
+GLuint pixel_depth_rb, pixel_depth_fb;
+size_t pixel_depth_rb_size;
+
+static struct GfxClipParameters gfx_opengl_get_clip_parameters(void) {
+    return { false, framebuffers[current_framebuffer].invert_y };
 }
 
 static void gfx_opengl_vertex_array_set_attribs(struct ShaderProgram *prg) {
@@ -82,7 +95,7 @@ static void gfx_opengl_vertex_array_set_attribs(struct ShaderProgram *prg) {
 static void gfx_opengl_set_uniforms(struct ShaderProgram *prg) {
     if (prg->used_noise) {
         glUniform1i(prg->frame_count_location, frame_count);
-        glUniform1i(prg->window_height_location, current_height);
+        glUniform1f(prg->noise_scale_location, current_noise_scale);
     }
 }
 
@@ -279,7 +292,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
         append_line(fs_buf, &fs_len, "uniform int frame_count;");
-        append_line(fs_buf, &fs_len, "uniform int window_height;");
+        append_line(fs_buf, &fs_len, "uniform float noise_scale;");
 
         append_line(fs_buf, &fs_len, "float random(in vec3 value) {");
         append_line(fs_buf, &fs_len, "    float random = dot(sin(value), vec3(12.9898, 78.233, 37.719));");
@@ -340,9 +353,9 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     }
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
-        append_line(fs_buf, &fs_len, "texel.a *= floor(clamp(random(vec3(floor(gl_FragCoord.xy * (240.0 / float(window_height))), float(frame_count))) + texel.a, 0.0, 1.0));");
+        append_line(fs_buf, &fs_len, "texel.a *= floor(clamp(random(vec3(floor(gl_FragCoord.xy * noise_scale), float(frame_count))) + texel.a, 0.0, 1.0));");
     }
-    
+
     if(cc_features.opt_grayscale) {
         append_line(fs_buf, &fs_len, "float light = (texel.r + texel.g + texel.b) / 7.0;");
         append_line(fs_buf, &fs_len, "texel.rgb = vec3(light, light, light);");
@@ -467,7 +480,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
 
     if (cc_features.opt_alpha && cc_features.opt_noise) {
         prg->frame_count_location = glGetUniformLocation(shader_program, "frame_count");
-        prg->window_height_location = glGetUniformLocation(shader_program, "window_height");
+        prg->noise_scale_location = glGetUniformLocation(shader_program, "noise_scale");
         prg->used_noise = true;
     } else {
         prg->used_noise = false;
@@ -503,7 +516,8 @@ static void gfx_opengl_select_texture(int tile, GLuint texture_id) {
 }
 
 static void gfx_opengl_upload_texture(const uint8_t *rgba32_buf, uint32_t width, uint32_t height) {
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
+    //glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
 }
 
 static uint32_t gfx_cm_to_opengl(uint32_t val) {
@@ -551,7 +565,6 @@ static void gfx_opengl_set_zmode_decal(bool zmode_decal) {
 
 static void gfx_opengl_set_viewport(int x, int y, int width, int height) {
     glViewport(x, y, width, height);
-    current_height = height;
 }
 
 static void gfx_opengl_set_scissor(int x, int y, int width, int height) {
@@ -572,10 +585,6 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
     glDrawArrays(GL_TRIANGLES, 0, 3 * buf_vbo_num_tris);
 }
 
-static unsigned int framebuffer;
-static unsigned int textureColorbuffer;
-static unsigned int rbo;
-
 static void gfx_opengl_init(void) {
 //#if FOR_WINDOWS
     glewInit();
@@ -584,144 +593,214 @@ static void gfx_opengl_init(void) {
     glGenBuffers(1, &opengl_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 
-    glGenFramebuffers(1, &framebuffer);
-    glGenTextures(1, &textureColorbuffer);
-    glGenRenderbuffers(1, &rbo);
-
-    SohUtils::saveEnvironmentVar("framebuffer", std::to_string(textureColorbuffer));
     glDepthFunc(GL_LEQUAL);
     //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+
+    framebuffers.resize(1); // for the default screen buffer
+
+    glGenRenderbuffers(1, &pixel_depth_rb);
+    glBindRenderbuffer(GL_RENDERBUFFER, pixel_depth_rb);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, 1, 1);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glGenFramebuffers(1, &pixel_depth_fb);
+    glBindFramebuffer(GL_FRAMEBUFFER, pixel_depth_fb);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, pixel_depth_rb);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    pixel_depth_rb_size = 1;
 }
 
 static void gfx_opengl_on_resize(void) {
 }
 
 static void gfx_opengl_start_frame(void) {
-    GLsizei framebuffer_width  = gfx_current_dimensions.width;
-    GLsizei framebuffer_height = gfx_current_dimensions.height;
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-    std::shared_ptr<Ship::Window> wnd = Ship::GlobalCtx2::GetInstance()->GetWindow();
-    glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, framebuffer_width, framebuffer_height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorbuffer, 0);
-    glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, framebuffer_width, framebuffer_height); // use a single renderbuffer object for both a depth AND stencil buffer.
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo); // now actually attach it
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-
     frame_count++;
-
-    glDisable(GL_SCISSOR_TEST);
-    glDepthMask(GL_TRUE);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glEnable(GL_SCISSOR_TEST);
-    glEnable(GL_DEPTH_CLAMP);
-    current_depth_mask = true;
 }
 
 static void gfx_opengl_end_frame(void) {
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
-
-    GLint last_program;
-    glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
-    glUseProgram(0);
-    SohImGui::Draw();
-    glUseProgram(last_program);
+    glFlush();
 }
 
 static void gfx_opengl_finish_render(void) {
 }
 
-static int gfx_opengl_create_framebuffer(uint32_t width, uint32_t height) {
-    GLuint textureColorbuffer;
-
-    glGenTextures(1, &textureColorbuffer);
-    glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+static int gfx_opengl_create_framebuffer() {
+    GLuint clrbuf;
+    glGenTextures(1, &clrbuf);
+    glBindTexture(GL_TEXTURE_2D, clrbuf);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, 1, 1, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glBindTexture(GL_TEXTURE_2D, 0);
 
+    GLuint clrbuf_msaa;
+    glGenRenderbuffers(1, &clrbuf_msaa);
+
     GLuint rbo;
     glGenRenderbuffers(1, &rbo);
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, 1, 1);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
     GLuint fbo;
     glGenFramebuffers(1, &fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    size_t i = framebuffers.size();
+    framebuffers.resize(i + 1);
 
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorbuffer, 0);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    framebuffers[i].fbo = fbo;
+    framebuffers[i].clrbuf = clrbuf;
+    framebuffers[i].clrbuf_msaa = clrbuf_msaa;
+    framebuffers[i].rbo = rbo;
 
-    fb2tex[fbo] = make_pair(textureColorbuffer, rbo);
-
-    //glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    return fbo;
+    return i;
 }
 
-static void gfx_opengl_resize_framebuffer(int fb, uint32_t width, uint32_t height) {
-    glBindTexture(GL_TEXTURE_2D, fb2tex[fb].first);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-    glBindTexture(GL_TEXTURE_2D, 0);
+static void gfx_opengl_update_framebuffer_parameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level, bool opengl_invert_y, bool render_target, bool has_depth_buffer, bool can_extract_depth) {
+    Framebuffer& fb = framebuffers[fb_id];
 
-    glBindRenderbuffer(GL_RENDERBUFFER, fb2tex[fb].second);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
-}
+    width = max(width, 1U);
+    height = max(height, 1U);
 
-void gfx_opengl_set_framebuffer(int fb)
-{
-    if (GLEW_ARB_clip_control || GLEW_VERSION_4_5) {
-        // Set origin to upper left corner, to match N64 and DX11
-        // If this function is not supported, the texture will be upside down :(
-        glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
+    glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+
+    if (fb_id != 0) {
+        if (fb.width != width || fb.height != height || fb.msaa_level != msaa_level) {
+            if (msaa_level <= 1) {
+                glBindTexture(GL_TEXTURE_2D, fb.clrbuf);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+                glBindTexture(GL_TEXTURE_2D, 0);
+                glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, fb.clrbuf, 0);
+            } else {
+                glBindRenderbuffer(GL_RENDERBUFFER, fb.clrbuf_msaa);
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_level, GL_RGB8, width, height);
+                glBindRenderbuffer(GL_RENDERBUFFER, 0);
+                glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, fb.clrbuf_msaa);
+            }
+        }
+
+        if (has_depth_buffer && (fb.width != width || fb.height != height || fb.msaa_level != msaa_level || !fb.has_depth_buffer)) {
+            glBindRenderbuffer(GL_RENDERBUFFER, fb.rbo);
+            if (msaa_level <= 1) {
+                glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+            } else {
+                glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_level, GL_DEPTH24_STENCIL8, width, height);
+            }
+            glBindRenderbuffer(GL_RENDERBUFFER, 0);
+        }
+
+        if (!fb.has_depth_buffer && has_depth_buffer) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, fb.rbo);
+        } else if (fb.has_depth_buffer && !has_depth_buffer) {
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, 0);
+        }
     }
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, fb);
+
+    fb.width = width;
+    fb.height = height;
+    fb.has_depth_buffer = has_depth_buffer;
+    fb.msaa_level = msaa_level;
+    fb.invert_y = opengl_invert_y;
+}
+
+void gfx_opengl_start_draw_to_framebuffer(int fb_id, float noise_scale) {
+    Framebuffer& fb = framebuffers[fb_id];
+
+    if (noise_scale != 0.0f) {
+        current_noise_scale = 1.0f / noise_scale;
+    }
+    glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+
+    current_framebuffer = fb_id;
+}
+
+void gfx_opengl_clear_framebuffer() {
+    glDisable(GL_SCISSOR_TEST);
 
     glDepthMask(GL_TRUE);
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
+    glEnable(GL_SCISSOR_TEST);
 }
 
-void gfx_opengl_reset_framebuffer(void)
-{
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-    glBindFramebuffer(GL_FRAMEBUFFER_EXT, framebuffer);
-    if (GLEW_ARB_clip_control || GLEW_VERSION_4_5) {
-        glClipControl(GL_LOWER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
-    }
+void gfx_opengl_resolve_msaa_color_buffer(int fb_id_target, int fb_id_source) {
+    Framebuffer& fb_dst = framebuffers[fb_id_target];
+    Framebuffer& fb_src = framebuffers[fb_id_source];
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb_dst.fbo);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, fb_src.fbo);
+    glBlitFramebuffer(0, 0, fb_src.width, fb_src.height, 0, 0, fb_dst.width, fb_dst.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, current_framebuffer);
 }
 
-void gfx_opengl_select_texture_fb(int fbID)
-{
+void *gfx_opengl_get_framebuffer_texture_id(int fb_id) {
+    return (void *)(uintptr_t)framebuffers[fb_id].clrbuf;
+}
+
+void gfx_opengl_select_texture_fb(int fb_id) {
     //glDisable(GL_DEPTH_TEST);
     glActiveTexture(GL_TEXTURE0 + 0);
-    glBindTexture(GL_TEXTURE_2D, fb2tex[fbID].first);
+    glBindTexture(GL_TEXTURE_2D, framebuffers[fb_id].clrbuf);
 }
 
-static uint16_t gfx_opengl_get_pixel_depth(float x, float y) {
-    float depth;
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-    glReadPixels(x, y, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    return depth * 65532.0f;
+static std::map<std::pair<float, float>, uint16_t> gfx_opengl_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& coordinates) {
+    std::map<std::pair<float, float>, uint16_t> res;
+
+    Framebuffer& fb = framebuffers[fb_id];
+
+    if (coordinates.size() == 1) {
+        uint32_t depth_stencil_value;
+        glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
+        int x = coordinates.begin()->first;
+        int y = coordinates.begin()->second;
+        glReadPixels(x, fb.invert_y ? fb.height - y : y, 1, 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, &depth_stencil_value);
+        res.emplace(*coordinates.begin(), (depth_stencil_value >> 18) << 2);
+    } else {
+        if (pixel_depth_rb_size < coordinates.size()) {
+            glBindRenderbuffer(GL_RENDERBUFFER, pixel_depth_rb);
+            glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, coordinates.size(), 1);
+            glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+            pixel_depth_rb_size = coordinates.size();
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fb.fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, pixel_depth_fb);
+
+        glDisable(GL_SCISSOR_TEST); // needed for the blit operation
+
+        {
+            size_t i = 0;
+            for (const auto& coord : coordinates) {
+                int x = coord.first;
+                int y = coord.second;
+                if (fb.invert_y) {
+                    y = fb.height - y;
+                }
+                glBlitFramebuffer(x, y, x + 1, y + 1, i, 0, i + 1, 1, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
+                ++i;
+            }
+        }
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, pixel_depth_fb);
+        vector<uint32_t> depth_stencil_values(coordinates.size());
+        glReadPixels(0, 0, coordinates.size(), 1, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, depth_stencil_values.data());
+
+        {
+            size_t i = 0;
+            for (const auto& coord : coordinates) {
+                res.emplace(coord, (depth_stencil_values[i++] >> 18) << 2);
+            }
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, current_framebuffer);
+    return res;
 }
 
 struct GfxRenderingAPI gfx_opengl_api = {
-    gfx_opengl_z_is_from_0_to_1,
+    gfx_opengl_get_clip_parameters,
     gfx_opengl_unload_shader,
     gfx_opengl_load_shader,
     gfx_opengl_create_and_load_new_shader,
@@ -732,7 +811,6 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_upload_texture,
     gfx_opengl_set_sampler_parameters,
     gfx_opengl_set_depth_test_and_mask,
-    gfx_opengl_get_pixel_depth,
     gfx_opengl_set_zmode_decal,
     gfx_opengl_set_viewport,
     gfx_opengl_set_scissor,
@@ -744,9 +822,12 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_end_frame,
     gfx_opengl_finish_render,
     gfx_opengl_create_framebuffer,
-    gfx_opengl_resize_framebuffer,
-    gfx_opengl_set_framebuffer,
-    gfx_opengl_reset_framebuffer,
+    gfx_opengl_update_framebuffer_parameters,
+    gfx_opengl_start_draw_to_framebuffer,
+    gfx_opengl_clear_framebuffer,
+    gfx_opengl_resolve_msaa_color_buffer,
+    gfx_opengl_get_pixel_depth,
+    gfx_opengl_get_framebuffer_texture_id,
     gfx_opengl_select_texture_fb,
     gfx_opengl_delete_texture
 };

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include <map>
+#include <set>
 #include <unordered_map>
 #include <vector>
 #include <list>
@@ -28,6 +29,8 @@
 
 #include "../../luslog.h"
 #include "../StrHash64.h"
+#include "../../SohImGuiImpl.h"
+#include "../../Environment.h"
 
 // OTRTODO: fix header files for these
 extern "C" {
@@ -70,10 +73,6 @@ using namespace std;
 
 struct RGBA {
     uint8_t r, g, b, a;
-};
-
-struct XYWidthHeight {
-    uint16_t x, y, width, height;
 };
 
 struct LoadedVertex {
@@ -157,7 +156,7 @@ static struct RDP {
     uint32_t other_mode_l, other_mode_h;
     uint64_t combine_mode;
     uint32_t gfx_effect;
-    
+
     uint8_t prim_lod_fraction;
     struct RGBA env_color, prim_color, fog_color, fill_color;
     struct XYWidthHeight viewport, scissor;
@@ -175,8 +174,16 @@ static struct RenderingState {
     TextureCacheNode *textures[2];
 } rendering_state;
 
+struct GfxDimensions gfx_current_window_dimensions;
 struct GfxDimensions gfx_current_dimensions;
 static struct GfxDimensions gfx_prev_dimensions;
+struct XYWidthHeight gfx_current_game_window_viewport;
+
+static bool game_renders_to_framebuffer;
+static int game_framebuffer;
+static int game_framebuffer_msaa_resolved;
+
+uint32_t gfx_msaa_level = 1;
 
 static bool dropped_frame;
 
@@ -198,6 +205,9 @@ struct FBInfo {
 static bool fbActive = 0;
 static map<int, FBInfo>::iterator active_fb;
 static map<int, FBInfo> framebuffers;
+
+static set<pair<float, float>> get_pixel_depth_pending;
+static map<pair<float, float>, uint16_t> get_pixel_depth_cached;
 
 #ifdef _MSC_VER
 // TODO: Properly implement for MSVC
@@ -1226,7 +1236,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     bool alpha_threshold = (rdp.other_mode_l & (3U << G_MDSFT_ALPHACOMPARE)) == G_AC_THRESHOLD;
     bool invisible = (rdp.other_mode_l & (3 << 24)) == (G_BL_0 << 24) && (rdp.other_mode_l & (3 << 20)) == (G_BL_CLR_MEM << 20);
     bool use_grayscale = rdp.gfx_effect == GRAYOUT;
-    
+
     if (texture_edge) {
         use_alpha = true;
     }
@@ -1239,7 +1249,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     if (alpha_threshold) cc_id |= (uint64_t)SHADER_OPT_ALPHA_THRESHOLD << CC_SHADER_OPT_POS;
     if (invisible) cc_id |= (uint64_t)SHADER_OPT_INVISIBLE << CC_SHADER_OPT_POS;
     if (use_grayscale) cc_id |= (uint64_t)SHADER_OPT_GRAYSCALE << CC_SHADER_OPT_POS;
-    
+
     if (!use_alpha) {
         cc_id &= ~((0xfff << 16) | ((uint64_t)0xfff << 44));
     }
@@ -1335,11 +1345,11 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
 
     gfx_rapi->shader_get_info(prg, &num_inputs, used_textures);
 
-    bool z_is_from_0_to_1 = gfx_rapi->z_is_from_0_to_1();
+    struct GfxClipParameters clip_parameters = gfx_rapi->get_clip_parameters();
 
     for (int i = 0; i < 3; i++) {
         float z = v_arr[i]->z, w = v_arr[i]->w;
-        if (z_is_from_0_to_1) {
+        if (clip_parameters.z_is_from_0_to_1) {
             z = (z + w) / 2.0f;
         }
 
@@ -1349,7 +1359,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         }
 
         buf_vbo[buf_vbo_len++] = v_arr[i]->x;
-        buf_vbo[buf_vbo_len++] = v_arr[i]->y;
+        buf_vbo[buf_vbo_len++] = clip_parameters.invert_y ? -v_arr[i]->y : v_arr[i]->y;
         buf_vbo[buf_vbo_len++] = z;
         buf_vbo[buf_vbo_len++] = w;
 
@@ -1500,6 +1510,27 @@ static void gfx_sp_geometry_mode(uint32_t clear, uint32_t set) {
     rsp.geometry_mode |= set;
 }
 
+static void gfx_adjust_viewport_or_scissor(XYWidthHeight *area) {
+    if (!fbActive) {
+        area->width *= RATIO_X;
+        area->height *= RATIO_Y;
+        area->x *= RATIO_X;
+        area->y = SCREEN_HEIGHT - area->y;
+        area->y *= RATIO_Y;
+
+        if (!game_renders_to_framebuffer || (gfx_msaa_level > 1 && gfx_current_dimensions.width == (uint32_t)gfx_current_game_window_viewport.width && gfx_current_dimensions.height == (uint32_t)gfx_current_game_window_viewport.height)) {
+            area->x += gfx_current_game_window_viewport.x;
+            area->y += gfx_current_window_dimensions.height - (gfx_current_game_window_viewport.y + gfx_current_game_window_viewport.height);
+        }
+    } else {
+        area->width *= RATIO_Y;
+        area->height *= RATIO_Y;
+        area->x *= RATIO_Y;
+        area->y = active_fb->second.orig_height - area->y;
+        area->y *= RATIO_Y;
+    }
+}
+
 static void gfx_calc_and_set_viewport(const Vp_t *viewport) {
     // 2 bits fraction
     float width = 2.0f * viewport->vscale[0] / 4.0f;
@@ -1507,24 +1538,12 @@ static void gfx_calc_and_set_viewport(const Vp_t *viewport) {
     float x = (viewport->vtrans[0] / 4.0f) - width / 2.0f;
     float y = ((viewport->vtrans[1] / 4.0f) + height / 2.0f);
 
-    if (!fbActive) {
-        width *= RATIO_X;
-        height *= RATIO_Y;
-        x *= RATIO_X;
-        y = SCREEN_HEIGHT - y;
-        y *= RATIO_Y;
-    } else {
-        width *= RATIO_Y;
-        height *= RATIO_Y;
-        x *= RATIO_Y;
-        y = active_fb->second.orig_height - y;
-        y *= RATIO_Y;
-    }
-
     rdp.viewport.x = x;
     rdp.viewport.y = y;
     rdp.viewport.width = width;
     rdp.viewport.height = height;
+
+    gfx_adjust_viewport_or_scissor(&rdp.viewport);
 
     rdp.viewport_or_scissor_changed = true;
 }
@@ -1594,11 +1613,6 @@ static void gfx_sp_texture(uint16_t sc, uint16_t tc, uint8_t level, uint8_t tile
         rdp.textures_changed[1] = true;
     }
 
-    if (tile > 8)
-    {
-        int bp = 0;
-    }
-
     rdp.first_tile_index = tile;
 }
 
@@ -1608,24 +1622,12 @@ static void gfx_dp_set_scissor(uint32_t mode, uint32_t ulx, uint32_t uly, uint32
     float width = (lrx - ulx) / 4.0f;
     float height = (lry - uly) / 4.0f;
 
-    if (!fbActive) {
-        x *= RATIO_X;
-        y = SCREEN_HEIGHT - y;
-        y *= RATIO_Y;
-        width *= RATIO_X;
-        height *= RATIO_Y;
-    } else {
-        width *= RATIO_Y;
-        height *= RATIO_Y;
-        x *= RATIO_Y;
-        y = active_fb->second.orig_height - y;
-        y *= RATIO_Y;
-    }
-
     rdp.scissor.x = x;
     rdp.scissor.y = y;
     rdp.scissor.width = width;
     rdp.scissor.height = height;
+
+    gfx_adjust_viewport_or_scissor(&rdp.scissor);
 
     rdp.viewport_or_scissor_changed = true;
 }
@@ -1886,9 +1888,11 @@ static void gfx_draw_rectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lr
     ur->w = 1.0f;
 
     // The coordinates for texture rectangle shall bypass the viewport setting
-    struct XYWidthHeight default_viewport = { 0, 0, gfx_current_dimensions.width, gfx_current_dimensions.height };
+    struct XYWidthHeight default_viewport = { 0, SCREEN_HEIGHT, SCREEN_WIDTH, SCREEN_HEIGHT };
     struct XYWidthHeight viewport_saved = rdp.viewport;
     uint32_t geometry_mode_saved = rsp.geometry_mode;
+
+    gfx_adjust_viewport_or_scissor(&default_viewport);
 
     rdp.viewport = default_viewport;
     rdp.viewport_or_scissor_changed = true;
@@ -2454,14 +2458,15 @@ static void gfx_run_dl(Gfx* cmd) {
                 gfx_flush();
                 fbActive = 1;
                 active_fb = framebuffers.find(cmd->words.w1);
-                gfx_rapi->set_framebuffer(active_fb->first);
+                gfx_rapi->start_draw_to_framebuffer(active_fb->first, (float)active_fb->second.applied_height / active_fb->second.orig_height);
+                gfx_rapi->clear_framebuffer();
             }
                 break;
             case G_RESETFB:
             {
                 gfx_flush();
                 fbActive = 0;
-                gfx_rapi->reset_framebuffer();
+                gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
                 break;
             }
             break;
@@ -2476,7 +2481,7 @@ static void gfx_run_dl(Gfx* cmd) {
                     //gfx_dp_set_texture_image(C0(21, 3), C0(19, 2), C0(0, 10), texPtr);
                 break;
             }
-			case G_SET_GFX_EFFECT:
+            case G_SET_GFX_EFFECT:
             {
                 rdp.gfx_effect = cmd->words.w1;
                 break;
@@ -2634,9 +2639,12 @@ void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, co
     gfx_rapi = rapi;
     gfx_wapi->init(game_name, start_in_fullscreen);
     gfx_rapi->init();
+    gfx_rapi->update_framebuffer_parameters(0, SCREEN_WIDTH, SCREEN_HEIGHT, 1, false, true, true, true);
     gfx_current_dimensions.internal_mul = 1;
     gfx_current_dimensions.width = SCREEN_WIDTH;
     gfx_current_dimensions.height = SCREEN_HEIGHT;
+    game_framebuffer = gfx_rapi->create_framebuffer();
+    game_framebuffer_msaa_resolved = gfx_rapi->create_framebuffer();
 
     for (int i = 0; i < 16; i++)
         segmentPointers[i] = 0;
@@ -2685,7 +2693,8 @@ struct GfxRenderingAPI *gfx_get_current_rendering_api(void) {
 
 void gfx_start_frame(void) {
     gfx_wapi->handle_events();
-    // gfx_wapi->get_dimensions(&gfx_current_dimensions.width, &gfx_current_dimensions.height);
+    gfx_wapi->get_dimensions(&gfx_current_window_dimensions.width, &gfx_current_window_dimensions.height);
+    SohImGui::DrawMainMenuAndCalculateGameSize();
     if (gfx_current_dimensions.height == 0) {
         // Avoid division by zero
         gfx_current_dimensions.height = 1;
@@ -2697,13 +2706,29 @@ void gfx_start_frame(void) {
             uint32_t width = fb.second.orig_width, height = fb.second.orig_height;
             gfx_adjust_width_height_for_scale(width, height);
             if (width != fb.second.applied_width || height != fb.second.applied_height) {
-                gfx_rapi->resize_framebuffer(fb.first, width, height);
+                gfx_rapi->update_framebuffer_parameters(fb.first, width, height, 1, true, true, true, true);
                 fb.second.applied_width = width;
                 fb.second.applied_height = height;
             }
         }
     }
     gfx_prev_dimensions = gfx_current_dimensions;
+
+    bool different_size = gfx_current_dimensions.width != (uint32_t)gfx_current_game_window_viewport.width || gfx_current_dimensions.height != (uint32_t)gfx_current_game_window_viewport.height;
+    if (different_size || gfx_msaa_level > 1) {
+        game_renders_to_framebuffer = true;
+        if (different_size) {
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer, gfx_current_dimensions.width, gfx_current_dimensions.height, gfx_msaa_level, true, true, true, true);
+        } else {
+            // MSAA framebuffer needs to be resolved to an equally sized target when complete, which must therefore match the window size
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer, gfx_current_window_dimensions.width, gfx_current_window_dimensions.height, gfx_msaa_level, false, true, true, true);
+        }
+        if (gfx_msaa_level > 1 && different_size) {
+            gfx_rapi->update_framebuffer_parameters(game_framebuffer_msaa_resolved, gfx_current_dimensions.width, gfx_current_dimensions.height, 1, false, false, false, false);
+        }
+    } else {
+        game_renders_to_framebuffer = false;
+    }
 
     fbActive = 0;
 }
@@ -2712,17 +2737,44 @@ void gfx_run(Gfx *commands) {
     gfx_sp_reset();
 
     //puts("New frame");
+    get_pixel_depth_pending.clear();
+    get_pixel_depth_cached.clear();
 
     if (!gfx_wapi->start_frame()) {
         dropped_frame = true;
+        SohImGui::DrawFramebufferAndGameInput();
+        SohImGui::CancelFrame();
         return;
     }
     dropped_frame = false;
 
     double t0 = gfx_wapi->get_time();
+    gfx_rapi->update_framebuffer_parameters(0, gfx_current_window_dimensions.width, gfx_current_window_dimensions.height, 1, false, true, true, !game_renders_to_framebuffer);
     gfx_rapi->start_frame();
+    gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
+    gfx_rapi->clear_framebuffer();
     gfx_run_dl(commands);
     gfx_flush();
+    SohUtils::saveEnvironmentVar("framebuffer", string());
+    if (game_renders_to_framebuffer) {
+        gfx_rapi->start_draw_to_framebuffer(0, 1);
+        gfx_rapi->clear_framebuffer();
+
+        if (gfx_msaa_level > 1) {
+            bool different_size = gfx_current_dimensions.width != (uint32_t)gfx_current_game_window_viewport.width || gfx_current_dimensions.height != (uint32_t)gfx_current_game_window_viewport.height;
+
+            if (different_size) {
+                gfx_rapi->resolve_msaa_color_buffer(game_framebuffer_msaa_resolved, game_framebuffer);
+                SohUtils::saveEnvironmentVar("framebuffer", std::to_string((uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer_msaa_resolved)));
+            } else {
+                gfx_rapi->resolve_msaa_color_buffer(0, game_framebuffer);
+            }
+        } else {
+            SohUtils::saveEnvironmentVar("framebuffer", std::to_string((uintptr_t)gfx_rapi->get_framebuffer_texture_id(game_framebuffer)));
+        }
+    }
+    SohImGui::DrawFramebufferAndGameInput();
+    SohImGui::Render();
     double t1 = gfx_wapi->get_time();
     //printf("Process %f %f\n", t1, t1 - t0);
     gfx_rapi->end_frame();
@@ -2743,21 +2795,47 @@ void gfx_set_framedivisor(int divisor) {
 int gfx_create_framebuffer(uint32_t width, uint32_t height) {
     uint32_t orig_width = width, orig_height = height;
     gfx_adjust_width_height_for_scale(width, height);
-    int fb = gfx_rapi->create_framebuffer(width, height);
+    int fb = gfx_rapi->create_framebuffer();
+    gfx_rapi->update_framebuffer_parameters(fb, width, height, 1, true, true, true, true);
     framebuffers[fb] = { orig_width, orig_height, width, height };
     return fb;
 }
 
-void gfx_set_framebuffer(int fb)
-{
-    gfx_rapi->set_framebuffer(fb);
+void gfx_set_framebuffer(int fb, float noise_scale) {
+    gfx_rapi->start_draw_to_framebuffer(fb, noise_scale);
+    gfx_rapi->clear_framebuffer();
 }
 
-void gfx_reset_framebuffer()
-{
-    gfx_rapi->reset_framebuffer();
+void gfx_reset_framebuffer() {
+    gfx_rapi->start_draw_to_framebuffer(0, (float)gfx_current_dimensions.height / SCREEN_HEIGHT);
+}
+
+static void adjust_pixel_depth_coordinates(float& x, float& y) {
+    x = x * RATIO_Y - (SCREEN_WIDTH * RATIO_Y - gfx_current_dimensions.width) / 2;
+    y *= RATIO_Y;
+    if (!game_renders_to_framebuffer || (gfx_msaa_level > 1 && gfx_current_dimensions.width == (uint32_t)gfx_current_game_window_viewport.width && gfx_current_dimensions.height == (uint32_t)gfx_current_game_window_viewport.height)) {
+        x += gfx_current_game_window_viewport.x;
+        y += gfx_current_window_dimensions.height - (gfx_current_game_window_viewport.y + gfx_current_game_window_viewport.height);
+    }
+}
+
+void gfx_get_pixel_depth_prepare(float x, float y) {
+    adjust_pixel_depth_coordinates(x, y);
+    get_pixel_depth_pending.emplace(x, y);
 }
 
 uint16_t gfx_get_pixel_depth(float x, float y) {
-    return gfx_rapi->get_pixel_depth(x * RATIO_Y - (SCREEN_WIDTH * RATIO_Y - gfx_current_dimensions.width) / 2, y * RATIO_Y);
+  adjust_pixel_depth_coordinates(x, y);
+
+  if (auto it = get_pixel_depth_cached.find(make_pair(x, y)); it != get_pixel_depth_cached.end()) {
+      return it->second;
+  }
+
+  get_pixel_depth_pending.emplace(x, y);
+
+  map<pair<float, float>, uint16_t> res = gfx_rapi->get_pixel_depth(game_renders_to_framebuffer ? game_framebuffer : 0, get_pixel_depth_pending);
+  get_pixel_depth_cached.merge(res);
+  get_pixel_depth_pending.clear();
+
+  return get_pixel_depth_cached.find(make_pair(x, y))->second;
 }

--- a/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_pc.h
@@ -9,8 +9,11 @@
 struct GfxRenderingAPI;
 struct GfxWindowManagerAPI;
 
-struct GfxDimensions
-{
+struct XYWidthHeight {
+    int16_t x, y, width, height;
+};
+
+struct GfxDimensions {
     uint32_t internal_mul;
     uint32_t width, height;
     float aspect_ratio;
@@ -22,7 +25,7 @@ struct TextureCacheKey {
     uint8_t palette_index;
 
     bool operator==(const TextureCacheKey&) const noexcept = default;
-     
+
     struct Hasher {
         size_t operator()(const TextureCacheKey& key) const noexcept {
             uintptr_t addr = (uintptr_t)key.texture_addr;
@@ -50,7 +53,11 @@ struct TextureCacheValue {
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern struct GfxDimensions gfx_current_dimensions;
+extern struct GfxDimensions gfx_current_window_dimensions; // The dimensions of the window
+extern struct GfxDimensions gfx_current_dimensions; // The dimensions of the draw area the game draws to, before scaling (if applicable)
+extern struct XYWidthHeight gfx_current_game_window_viewport; // The area of the window the game is drawn to, (0, 0) is top-left corner
+extern uint32_t gfx_msaa_level;
+
 
 void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, const char* game_name, bool start_in_fullscreen);
 struct GfxRenderingAPI* gfx_get_current_rendering_api(void);
@@ -60,6 +67,7 @@ void gfx_end_frame(void);
 void gfx_set_framedivisor(int);
 void gfx_texture_cache_clear();
 int gfx_create_framebuffer(uint32_t width, uint32_t height);
+void gfx_get_pixel_depth_prepare(float x, float y);
 uint16_t gfx_get_pixel_depth(float x, float y);
 
 #ifdef __cplusplus

--- a/libultraship/libultraship/Lib/Fast3D/gfx_rendering_api.h
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_rendering_api.h
@@ -5,10 +5,18 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <map>
+#include <set>
+
 struct ShaderProgram;
 
+struct GfxClipParameters {
+    bool z_is_from_0_to_1;
+    bool invert_y;
+};
+
 struct GfxRenderingAPI {
-    bool (*z_is_from_0_to_1)(void);
+    struct GfxClipParameters (*get_clip_parameters)(void);
     void (*unload_shader)(struct ShaderProgram *old_prg);
     void (*load_shader)(struct ShaderProgram *new_prg);
     struct ShaderProgram *(*create_and_load_new_shader)(uint64_t shader_id0, uint32_t shader_id1);
@@ -19,7 +27,6 @@ struct GfxRenderingAPI {
     void (*upload_texture)(const uint8_t *rgba32_buf, uint32_t width, uint32_t height);
     void (*set_sampler_parameters)(int sampler, bool linear_filter, uint32_t cms, uint32_t cmt);
     void (*set_depth_test_and_mask)(bool depth_test, bool z_upd);
-    uint16_t (*get_pixel_depth)(float x, float y);
     void (*set_zmode_decal)(bool zmode_decal);
     void (*set_viewport)(int x, int y, int width, int height);
     void (*set_scissor)(int x, int y, int width, int height);
@@ -30,11 +37,14 @@ struct GfxRenderingAPI {
     void (*start_frame)(void);
     void (*end_frame)(void);
     void (*finish_render)(void);
-    int (*create_framebuffer)(uint32_t width, uint32_t height);
-    void (*resize_framebuffer)(int fb, uint32_t width, uint32_t height);
-    void (*set_framebuffer)(int fb);
-    void (*reset_framebuffer)();
-    void (*select_texture_fb)(int fbID);
+    int (*create_framebuffer)();
+    void (*update_framebuffer_parameters)(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level, bool opengl_invert_y, bool render_target, bool has_depth_buffer, bool can_extract_depth);
+    void (*start_draw_to_framebuffer)(int fb_id, float noise_scale);
+    void (*clear_framebuffer)(void);
+    void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
+    std::map<std::pair<float, float>, uint16_t> (*get_pixel_depth)(int fb_id, const std::set<std::pair<float, float>>& coordinates);
+    void *(*get_framebuffer_texture_id)(int fb_id);
+    void (*select_texture_fb)(int fb_id);
     void (*delete_texture)(uint32_t texID);
 };
 

--- a/libultraship/libultraship/SDLController.cpp
+++ b/libultraship/libultraship/SDLController.cpp
@@ -59,10 +59,12 @@ namespace Ship {
                 if (Conf[ConfSection]["GUID"].compare("") == 0 || Conf[ConfSection]["GUID"].compare(INVALID_SDL_CONTROLLER_GUID) == 0 || Conf[ConfSection]["GUID"].compare(NewGuid) == 0) {
                     auto NewCont = SDL_GameControllerOpen(i);
 
+                    //  /* Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
                     if (SDL_GameControllerHasSensor(NewCont, SDL_SENSOR_GYRO))
                     {
                         SDL_GameControllerSetSensorEnabled(NewCont, SDL_SENSOR_GYRO, SDL_TRUE);
                     }
+                    //  */ Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
 
                     // We failed to load the controller. Go to next.
                     if (NewCont == nullptr) {
@@ -176,6 +178,7 @@ namespace Ship {
             }
         }
 
+        //  /* Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
         if (SDL_GameControllerHasSensor(Cont, SDL_SENSOR_GYRO))
         {
             float gyroData[3];
@@ -210,6 +213,7 @@ namespace Ship {
             wGyroX *= gyroSensitivity;
             wGyroY *= gyroSensitivity;
         }
+        //  */ Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
 
         for (int32_t i = SDL_CONTROLLER_BUTTON_A; i < SDL_CONTROLLER_BUTTON_MAX; i++) {
             if (ButtonMapping.contains(i)) {
@@ -336,6 +340,7 @@ namespace Ship {
         //     }
         // }
 
+        //  /* Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
         if (SDL_GameControllerHasLED(Cont)) {
             switch (controller->ledColor) {
             case 0:
@@ -352,6 +357,7 @@ namespace Ship {
                 break;
             }
         }
+        //  */ Uncomment me if you want to build for Ubuntu 20.04 and probably lower !
     }
 
     void SDLController::CreateDefaultBinding() {

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -42,14 +42,24 @@ bool oldCursorState = true;
 OSContPad* pads;
 
 std::map<std::string, GameAsset*> DefaultAssets;
-
 namespace SohImGui {
-
     WindowImpl impl;
     ImGuiIO* io;
     Console* console = new Console;
     bool p_open = false;
     bool needs_save = false;
+
+    float hearts_colors[3] = {0,0,0};
+    float hearts_dd_colors[3] = {0,0,0};
+    float a_btn_colors[3] = {0,0,0};
+    float b_btn_colors[3] = {0,0,0};
+    float c_btn_colors[3] = {0,0,0};
+    float start_btn_colors[3] = {0,0,0};
+    float magic_border_colors[3] = {0,0,0};
+    float magic_remaining_colors[3] = {0,0,0};
+    float magic_use_colors[3] = {0,0,0};
+    float minimap_colors[3] = {0,0,0};
+    float rupee_colors[3] = {0,0,0};
 
     void ImGuiWMInit() {
         switch (impl.backend) {
@@ -142,14 +152,14 @@ namespace SohImGui {
         }
     }
 
-    bool UseInternalRes() {
+    /*bool UseInternalRes() {
         switch (impl.backend) {
         case Backend::SDL:
             return true;
         default:
             return false;
         }
-    }
+    }*/
 
     bool UseViewports() {
         switch (impl.backend) {
@@ -200,6 +210,49 @@ namespace SohImGui {
         stbi_image_free(img_data);
     }
 
+    void LoadHudColors(){//This function is necessary as without it IMGui wont load the updated float array.
+        hearts_colors[0] = (float)CVar_GetInt("gCCHeartsPrimR", 255)/255;
+        hearts_colors[1] = (float)CVar_GetInt("gCCHeartsPrimG", 10)/255;
+        hearts_colors[2] = (float)CVar_GetInt("gCCHeartsPrimB", 10)/255;
+        hearts_dd_colors[0] = (float)CVar_GetInt("gDDCCHeartsPrimR", 255)/255;
+        hearts_dd_colors[1] = (float)CVar_GetInt("gDDCCHeartsPrimG", 255)/255;
+        hearts_dd_colors[2] = (float)CVar_GetInt("gDDCCHeartsPrimB", 255)/255;
+        a_btn_colors[0] = (float)CVar_GetInt("gCCABtnPrimR", 90)/255;
+        a_btn_colors[1] = (float)CVar_GetInt("gCCABtnPrimG", 90)/255;
+        a_btn_colors[2] = (float)CVar_GetInt("gCCABtnPrimB", 255)/255;
+        b_btn_colors[0] = (float)CVar_GetInt("gCCBBtnPrimR", 0)/255;
+        b_btn_colors[1] = (float)CVar_GetInt("gCCBBtnPrimG", 150)/255;
+        b_btn_colors[2] = (float)CVar_GetInt("gCCBBtnPrimB", 0)/255;
+        c_btn_colors[0] = (float)CVar_GetInt("gCCCBtnPrimR", 255)/255;
+        c_btn_colors[1] = (float)CVar_GetInt("gCCCBtnPrimG", 160)/255;
+        c_btn_colors[2] = (float)CVar_GetInt("gCCCBtnPrimB", 0)/255;
+        start_btn_colors[0] = (float)CVar_GetInt("gCCStartBtnPrimR", 120)/255;
+        start_btn_colors[1] = (float)CVar_GetInt("gCCStartBtnPrimG", 120)/255;
+        start_btn_colors[2] = (float)CVar_GetInt("gCCStartBtnPrimB", 120)/255;
+        magic_border_colors[0] = (float)CVar_GetInt("gCCMagicBorderPrimR", 255)/255;
+        magic_border_colors[1] = (float)CVar_GetInt("gCCMagicBorderPrimG", 255)/255;
+        magic_border_colors[2] = (float)CVar_GetInt("gCCMagicBorderPrimB", 255)/255;
+        magic_remaining_colors[0] = (float)CVar_GetInt("gCCMagicPrimR", 250)/255;
+        magic_remaining_colors[1] = (float)CVar_GetInt("gCCMagicPrimG", 250)/255;
+        magic_remaining_colors[2] = (float)CVar_GetInt("gCCMagicPrimB", 0)/255;
+        magic_remaining_colors[0] = (float)CVar_GetInt("gCCMagicUsePrimR", 0)/255;
+        magic_remaining_colors[1] = (float)CVar_GetInt("gCCMagicUsePrimG", 200)/255;
+        magic_remaining_colors[2] = (float)CVar_GetInt("gCCMagicUsePrimB", 0)/255;
+        minimap_colors[0] = (float)CVar_GetInt("gCCMinimapPrimR", 0)/255;
+        minimap_colors[1] = (float)CVar_GetInt("gCCMinimapPrimG", 255)/255;
+        minimap_colors[2] = (float)CVar_GetInt("gCCMinimapPrimB", 255)/255;
+        rupee_colors[0] = (float)CVar_GetInt("gCCRupeePrimR", 120)/255;
+        rupee_colors[1] = (float)CVar_GetInt("gCCRupeePrimG", 120)/255;
+        rupee_colors[2] = (float)CVar_GetInt("gCCRupeePrimB", 120)/255;
+    } 
+
+    int ClampFloatToInt(float value, int min, int max){
+        return fmin(fmax(value,min),max);
+    }
+    float ClampIntToFloat(int value, float min, float max){
+        return fmin(fmax(value,min),max);
+    }
+
     void Init(WindowImpl window_impl) {
         impl = window_impl;
         Game::LoadSettings();
@@ -213,7 +266,7 @@ namespace SohImGui {
         console->Init();
         ImGuiWMInit();
         ImGuiBackendInit();
-
+        LoadHudColors();
         ModInternal::registerHookListener({ GFX_INIT, [](const HookEvent ev) {
 
             if (GlobalCtx2::GetInstance()->GetWindow()->IsFullscreen())
@@ -237,6 +290,7 @@ namespace SohImGui {
             pads = static_cast<OSContPad*>(ev->baseArgs["cont_pad"]);
         } });
         Game::InitSettings();
+        //LoadHUDColors();
     }
 
     void Update(EventImpl event) {
@@ -261,16 +315,15 @@ namespace SohImGui {
             Game::SetSeqPlayerVolume(playerId, volume);
         }
     }
-
-    void Draw() {
+    //void Draw() {
+    void DrawMainMenuAndCalculateGameSize() {
 
         console->Update();
         ImGuiBackendNewFrame();
         ImGuiWMNewFrame();
         ImGui::NewFrame();
-
         const std::shared_ptr<Window> wnd = GlobalCtx2::GetInstance()->GetWindow();
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking |
+        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
             ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoResize;
         if (UseViewports()) {
@@ -283,8 +336,12 @@ namespace SohImGui {
         ImGui::SetNextWindowSize(ImVec2(wnd->GetCurrentWidth(), wnd->GetCurrentHeight()));
         ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
         ImGui::Begin("Main - Deck", nullptr, window_flags);
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar(3);
+
+        ImVec2 top_left_pos = ImGui::GetWindowPos();
 
         const ImGuiID dockId = ImGui::GetID("main_dock");
 
@@ -403,10 +460,10 @@ namespace SohImGui {
                     needs_save = true;
                 }
 
-                if (ImGui::Checkbox("Fix L&R Pause menu", &Game::Settings.enhancements.uniform_lr)) {
+                /*if (ImGui::Checkbox("Fix L&R Pause menu", &Game::Settings.enhancements.uniform_lr)) {
                     CVar_SetS32("gUniformLR", Game::Settings.enhancements.uniform_lr);
                     needs_save = true;
-                }
+                } */
 
                 ImGui::Text("Graphics");
                 ImGui::Separator();
@@ -433,20 +490,10 @@ namespace SohImGui {
                     needs_save = true;
                 }
 
-                if (ImGui::Checkbox("Enable N64 Color", &Game::Settings.enhancements.n64color)) {
-                    CVar_SetS32("gN64Color", Game::Settings.enhancements.n64color);
-                    needs_save = true;
-                }
-
                 if (ImGui::Checkbox("Enable Visual/Audio Stone of Agony", &Game::Settings.enhancements.visualagony)) {
                     CVar_SetS32("gVisualAgony", Game::Settings.enhancements.visualagony);
                     needs_save = true;
                 }
-
-                /*if (ImGui::Checkbox("Enable Masks abilities", &Game::Settings.enhancements.maskability)) {
-                    CVar_SetS32("gMaskAbility", Game::Settings.enhancements.maskability);
-                    needs_save = true;
-                }*/
 
                 ImGui::EndMenu();
             }
@@ -530,23 +577,218 @@ namespace SohImGui {
                 ImGui::EndMenu();
             }
 
+            if (ImGui::BeginMenu("Graphics")) {
+                HOOK(ImGui::MenuItem("Anti-aliasing", nullptr, &Game::Settings.graphics.show));
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("HUD Colors")) {
+                if (ImGui::RadioButton("N64 Colors", CVar_GetS32("gN64Colors", 1))) {
+                    Game::Settings.hudcolors.n64_colors = 1;
+                    Game::Settings.hudcolors.gc_colors = 0;
+                    Game::Settings.hudcolors.custom_colors = 0;
+                    CVar_SetS32("gN64Colors", 1);
+                    CVar_SetS32("gGameCubeColors", 0);
+                    CVar_SetS32("gCustomColors", 0);
+                    needs_save = true;
+                }
+                if (ImGui::RadioButton("Gamecube Colors", CVar_GetS32("gGameCubeColors", 0))) {
+                    Game::Settings.hudcolors.n64_colors = 0;
+                    Game::Settings.hudcolors.gc_colors = 1;
+                    Game::Settings.hudcolors.custom_colors = 0;
+                    CVar_SetS32("gN64Colors", 0);
+                    CVar_SetS32("gGameCubeColors", 1);
+                    CVar_SetS32("gCustomColors", 0);
+                    needs_save = true;
+                }
+                if (ImGui::RadioButton("Custom Colors", CVar_GetS32("gCustomColors", 0))) {
+                    Game::Settings.hudcolors.n64_colors = 0;
+                    Game::Settings.hudcolors.gc_colors = 0;
+                    Game::Settings.hudcolors.custom_colors = 1;
+                    CVar_SetS32("gN64Colors", 0);
+                    CVar_SetS32("gGameCubeColors", 0);
+                    CVar_SetS32("gCustomColors", 1);
+                    needs_save = true;
+                }
+                bool OpenColorEdit = ImGui::SmallButton("Edit HUD Colors");
+                bool Hearts_col=false;
+                bool Hearts_dd_col=false;
+                bool Buttons_col=false;
+                bool Magic_col=false;
+                bool Minimap_col=false;
+                bool Rupee_col=false;
+                if (OpenColorEdit) {
+                     ImGui::OpenPopup("CustomColors");
+                }
+                if (ImGui::BeginPopup("CustomColors")){
+                    ImGui::Text("Edit custom HUD colors");
+                    ImGui::Separator();
+                    Hearts_col = ImGui::SmallButton("Hearts colors");
+                    ImGui::Separator();
+                    Hearts_dd_col = ImGui::SmallButton("Hearts double defense colors");
+                    ImGui::Separator();
+                    Buttons_col = ImGui::SmallButton("Buttons");
+                    ImGui::Separator();
+                    Magic_col = ImGui::SmallButton("Magic Bar");
+                    ImGui::Separator();
+                    Minimap_col = ImGui::SmallButton("Minimap");
+                    ImGui::Separator();
+                    Rupee_col = ImGui::SmallButton("Rupee icon");
+                    ImGui::EndPopup();
+                }
+                if (Hearts_col) { ImGui::OpenPopup("Hearts_col"); }
+                if (Hearts_dd_col) { ImGui::OpenPopup("Hearts_dd_col"); }
+                if (Buttons_col) { ImGui::OpenPopup("Buttons_col"); }
+                if (Magic_col) { ImGui::OpenPopup("Magic_col"); }
+                if (Minimap_col) { ImGui::OpenPopup("Minimap_col"); }
+                if (Rupee_col) { ImGui::OpenPopup("Rupee_col"); }
+                if (ImGui::BeginPopup("Hearts_col")){
+                    if (ImGui::ColorEdit3("Hearts", (float*)&hearts_colors)) {
+                        Game::Settings.hudcolors.ccheartsprimr = ClampFloatToInt(hearts_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccheartsprimg = ClampFloatToInt(hearts_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccheartsprimb = ClampFloatToInt(hearts_colors[2]*255,0,255);
+                        CVar_SetInt("gCCHeartsPrimR", Game::Settings.hudcolors.ccheartsprimr);
+                        CVar_SetInt("gCCHeartsPrimG", Game::Settings.hudcolors.ccheartsprimg);
+                        CVar_SetInt("gCCHeartsPrimB", Game::Settings.hudcolors.ccheartsprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+                if (ImGui::BeginPopup("Hearts_dd_col")){
+                    if (ImGui::ColorEdit3("Hearts", hearts_dd_colors)) {
+                        Game::Settings.hudcolors.ddccheartsprimr = ClampFloatToInt(hearts_dd_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ddccheartsprimg = ClampFloatToInt(hearts_dd_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ddccheartsprimb = ClampFloatToInt(hearts_dd_colors[2]*255,0,255);
+                        CVar_SetInt("gDDCCHeartsPrimR", Game::Settings.hudcolors.ddccheartsprimr);
+                        CVar_SetInt("gDDCCHeartsPrimG", Game::Settings.hudcolors.ddccheartsprimg);
+                        CVar_SetInt("gDDCCHeartsPrimB", Game::Settings.hudcolors.ddccheartsprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+                if (ImGui::BeginPopup("Buttons_col")){
+                    if (ImGui::ColorEdit3("A Buttons", a_btn_colors)) {
+                        Game::Settings.hudcolors.ccabtnprimr = ClampFloatToInt(a_btn_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccabtnprimg = ClampFloatToInt(a_btn_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccabtnprimb = ClampFloatToInt(a_btn_colors[2]*255,0,255);
+                        CVar_SetInt("gCCABtnPrimR", Game::Settings.hudcolors.ccabtnprimr);
+                        CVar_SetInt("gCCABtnPrimG", Game::Settings.hudcolors.ccabtnprimg);
+                        CVar_SetInt("gCCABtnPrimB", Game::Settings.hudcolors.ccabtnprimb);
+                        needs_save = true;
+                    }
+                    if (ImGui::ColorEdit3("B Buttons", b_btn_colors)) {
+                        Game::Settings.hudcolors.ccbbtnprimr = ClampFloatToInt(b_btn_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccbbtnprimg = ClampFloatToInt(b_btn_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccbbtnprimb = ClampFloatToInt(b_btn_colors[2]*255,0,255);
+                        CVar_SetInt("gCCBBtnPrimR", Game::Settings.hudcolors.ccbbtnprimr);
+                        CVar_SetInt("gCCBBtnPrimG", Game::Settings.hudcolors.ccbbtnprimg);
+                        CVar_SetInt("gCCBBtnPrimB", Game::Settings.hudcolors.ccbbtnprimb);
+                        needs_save = true;
+                    }
+                    if (ImGui::ColorEdit3("C Buttons", c_btn_colors)) {
+                        Game::Settings.hudcolors.cccbtnprimr = ClampFloatToInt(c_btn_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.cccbtnprimg = ClampFloatToInt(c_btn_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.cccbtnprimb = ClampFloatToInt(c_btn_colors[2]*255,0,255);
+                        CVar_SetInt("gCCCBtnPrimR", Game::Settings.hudcolors.cccbtnprimr);
+                        CVar_SetInt("gCCCBtnPrimG", Game::Settings.hudcolors.cccbtnprimg);
+                        CVar_SetInt("gCCCBtnPrimB", Game::Settings.hudcolors.cccbtnprimb);
+                        needs_save = true;
+                    }
+                    if (ImGui::ColorEdit3("Start Button", start_btn_colors)) {
+                        Game::Settings.hudcolors.ccstartbtnprimr = ClampFloatToInt(start_btn_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccstartbtnprimg = ClampFloatToInt(start_btn_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccstartbtnprimb = ClampFloatToInt(start_btn_colors[2]*255,0,255);
+                        CVar_SetInt("gCCStartBtnPrimR", Game::Settings.hudcolors.ccstartbtnprimr);
+                        CVar_SetInt("gCCStartBtnPrimG", Game::Settings.hudcolors.ccstartbtnprimg);
+                        CVar_SetInt("gCCStartBtnPrimB", Game::Settings.hudcolors.ccstartbtnprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+                if (ImGui::BeginPopup("Magic_col")){
+                    if (ImGui::ColorEdit3("Magic bar borders", magic_border_colors)) {
+                        Game::Settings.hudcolors.ccmagicborderprimr = ClampFloatToInt(magic_border_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicborderprimg = ClampFloatToInt(magic_border_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicborderprimb = ClampFloatToInt(magic_border_colors[2]*255,0,255);
+                        CVar_SetInt("gCCMagicBorderPrimR", Game::Settings.hudcolors.ccmagicborderprimr);
+                        CVar_SetInt("gCCMagicBorderPrimG", Game::Settings.hudcolors.ccmagicborderprimg);
+                        CVar_SetInt("gCCMagicBorderPrimB", Game::Settings.hudcolors.ccmagicborderprimb);
+                        needs_save = true;
+                    }
+                    if (ImGui::ColorEdit3("Magic bar main color", magic_remaining_colors)) {
+                        Game::Settings.hudcolors.ccmagicprimr = ClampFloatToInt(magic_remaining_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicprimg = ClampFloatToInt(magic_remaining_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicprimb = ClampFloatToInt(magic_remaining_colors[2]*255,0,255);
+                        CVar_SetInt("gCCMagicPrimR", Game::Settings.hudcolors.ccmagicprimr);
+                        CVar_SetInt("gCCMagicPrimG", Game::Settings.hudcolors.ccmagicprimg);
+                        CVar_SetInt("gCCMagicPrimB", Game::Settings.hudcolors.ccmagicprimb);
+                        needs_save = true;
+                    }
+                    if (ImGui::ColorEdit3("Magic bar being used", magic_use_colors)) {
+                        Game::Settings.hudcolors.ccmagicuseprimr = ClampFloatToInt(magic_use_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicuseprimg = ClampFloatToInt(magic_use_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccmagicuseprimb = ClampFloatToInt(magic_use_colors[2]*255,0,255);
+                        CVar_SetInt("CCMagicUsePrimR", Game::Settings.hudcolors.ccmagicuseprimr);
+                        CVar_SetInt("CCMagicUsePrimG", Game::Settings.hudcolors.ccmagicuseprimg);
+                        CVar_SetInt("CCMagicUsePrimB", Game::Settings.hudcolors.ccmagicuseprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+                if (ImGui::BeginPopup("Minimap_col")){
+                    if (ImGui::ColorEdit3("Minimap color", minimap_colors)) {
+                        Game::Settings.hudcolors.ccminimapprimr = ClampFloatToInt(minimap_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccminimapprimg = ClampFloatToInt(minimap_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccminimapprimb = ClampFloatToInt(minimap_colors[2]*255,0,255);
+                        CVar_SetInt("gCCMinimapPrimR", Game::Settings.hudcolors.ccminimapprimr);
+                        CVar_SetInt("gCCMinimapPrimG", Game::Settings.hudcolors.ccminimapprimg);
+                        CVar_SetInt("gCCMinimapPrimB", Game::Settings.hudcolors.ccminimapprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+                if (ImGui::BeginPopup("Rupee_col")){
+                    if (ImGui::ColorEdit3("Rupee icon color", rupee_colors)) {
+                        Game::Settings.hudcolors.ccrupeeprimr = ClampFloatToInt(rupee_colors[0]*255,0,255);
+                        Game::Settings.hudcolors.ccrupeeprimg = ClampFloatToInt(rupee_colors[1]*255,0,255);
+                        Game::Settings.hudcolors.ccrupeeprimb = ClampFloatToInt(rupee_colors[2]*255,0,255);
+                        CVar_SetInt("gCCRupeePrimR", Game::Settings.hudcolors.ccrupeeprimr);
+                        CVar_SetInt("gCCRupeePrimG", Game::Settings.hudcolors.ccrupeeprimg);
+                        CVar_SetInt("gCCRupeePrimB", Game::Settings.hudcolors.ccrupeeprimb);
+                        needs_save = true;
+                    }
+                    ImGui::EndPopup();
+                }
+
+                ImGui::EndMenu();
+            }
+
             if (ImGui::BeginMenu("Languages")) {
-                if (ImGui::Checkbox("English", &Game::Settings.languages.set_eng)) {
+                if (ImGui::RadioButton("English", CVar_GetS32("gSetENG", 1))) {
+                    Game::Settings.languages.set_eng = 1;
+                    Game::Settings.languages.set_fra = 0;
+                    Game::Settings.languages.set_ger = 0;
                     CVar_SetS32("gSetENG", 1);
                     CVar_SetS32("gSetFRA", 0);
                     CVar_SetS32("gSetGER", 0);
                     needs_save = true;
                 }
-                if (ImGui::Checkbox("French", &Game::Settings.languages.set_fra)) {
-                    CVar_SetS32("gSetFRA", 1);
-                    CVar_SetS32("gSetENG", 0);
-                    CVar_SetS32("gSetGER", 0);
-                    needs_save = true;
-                }
-                if (ImGui::Checkbox("German", &Game::Settings.languages.set_ger)) {
-                    CVar_SetS32("gSetGER", 1);
+                  if (ImGui::RadioButton("German", CVar_GetS32("gSetGER", 0))) {
+                    Game::Settings.languages.set_eng = 0;
+                    Game::Settings.languages.set_fra = 0;
+                    Game::Settings.languages.set_ger = 1;
                     CVar_SetS32("gSetENG", 0);
                     CVar_SetS32("gSetFRA", 0);
+                    CVar_SetS32("gSetGER", 1);
+                    needs_save = true;
+                }
+                if (ImGui::RadioButton("French", CVar_GetS32("gSetFRA", 0))) {
+                    Game::Settings.languages.set_eng = 0;
+                    Game::Settings.languages.set_fra = 1;
+                    Game::Settings.languages.set_ger = 0;
+                    CVar_SetS32("gSetENG", 0);
+                    CVar_SetS32("gSetFRA", 1);
+                    CVar_SetS32("gSetGER", 0);
                     needs_save = true;
                 }
                 ImGui::EndMenu();
@@ -556,106 +798,122 @@ namespace SohImGui {
         }
 
         ImGui::End();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-        ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-        if (UseViewports()) {
-            flags |= ImGuiWindowFlags_NoBackground;
-        }
-        ImGui::Begin("OoT Master Quest", nullptr, flags);
-        ImGui::PopStyleVar();
-        ImGui::PopStyleColor();
 
-        ImVec2 main_pos = ImGui::GetWindowPos();
-        ImVec2 size = ImGui::GetContentRegionAvail();
-        ImVec2 pos = ImVec2(0, 0);
-        gfx_current_dimensions.width = size.x * gfx_current_dimensions.internal_mul;
-        gfx_current_dimensions.height = size.y * gfx_current_dimensions.internal_mul;
-        if (UseInternalRes()) {
-            if (Game::Settings.debug.n64mode) {
-                gfx_current_dimensions.width = 320;
-                gfx_current_dimensions.height = 240;
-                const int sw = size.y * 320 / 240;
-                pos = ImVec2(size.x / 2 - sw / 2, 0);
-                size = ImVec2(sw, size.y);
-            }
-        }
-
-        if (UseInternalRes()) {
-            int fbuf = std::stoi(SohUtils::getEnvironmentVar("framebuffer"));
-            ImGui::ImageRotated(reinterpret_cast<ImTextureID>(fbuf), pos, size, 0.0f);
-        }
-        ImGui::End();
-
-        if (Game::Settings.debug.soh) {
-            const float framerate = ImGui::GetIO().Framerate;
+        if (Game::Settings.graphics.show) {
             ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
-            ImGui::Begin("Debug Stats", nullptr, ImGuiWindowFlags_None);
-
-#ifdef _MSC_VER
-            ImGui::Text("Platform: Windows");
-#else
-            ImGui::Text("Platform: Linux");
-#endif
-            ImGui::Text("Status: %.3f ms/frame (%.1f FPS)", 1000.0f / framerate, framerate);
-            if (UseInternalRes()) {
-                ImGui::Text("Internal Resolution:");
-                ImGui::SliderInt("Mul", reinterpret_cast<int*>(&gfx_current_dimensions.internal_mul), 1, 8);
-            }
+            ImGui::Begin("Anti-aliasing settings", nullptr, ImGuiWindowFlags_None);
+            ImGui::Text("Internal Resolution:");
+            ImGui::SliderInt("Mul", reinterpret_cast<int*>(&gfx_current_dimensions.internal_mul), 1, 8);
+            ImGui::Text("MSAA:");
+            ImGui::SliderInt("MSAA", reinterpret_cast<int*>(&gfx_msaa_level), 1, 8);
             ImGui::End();
             ImGui::PopStyleColor();
         }
 
-        const float scale = Game::Settings.controller.input_scale;
-        ImVec2 BtnPos = ImVec2(160 * scale, 85 * scale);
+        console->Draw();
 
-        if(Game::Settings.controller.input_enabled) {
-            ImGui::SetNextWindowSize(BtnPos);
-            ImGui::SetNextWindowPos(ImVec2(main_pos.x + size.x - BtnPos.x - 20, main_pos.y + size.y - BtnPos.y - 20));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 0.0f);
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+        ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground;
+        ImGui::Begin("OoT Master Quest", nullptr, flags);
+        ImGui::PopStyleVar(3);
+        ImGui::PopStyleColor();
 
-            if (pads != nullptr && ImGui::Begin("Game Buttons", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBackground)) {
-                ImGui::SetCursorPosY(32 * scale);
-
-                ImGui::BeginGroup();
-                const ImVec2 cPos = ImGui::GetCursorPos();
-                ImGui::SetCursorPos(ImVec2(cPos.x + 10 * scale, cPos.y - 20 * scale));
-                BindButton("L-Btn", pads[0].button & BTN_L);
-                ImGui::SetCursorPos(ImVec2(cPos.x + 16 * scale, cPos.y));
-                BindButton("C-Up", pads[0].button & BTN_CUP);
-                ImGui::SetCursorPos(ImVec2(cPos.x, cPos.y + 16 * scale));
-                BindButton("C-Left", pads[0].button & BTN_CLEFT);
-                ImGui::SetCursorPos(ImVec2(cPos.x + 32 * scale, cPos.y + 16 * scale));
-                BindButton("C-Right", pads[0].button & BTN_CRIGHT);
-                ImGui::SetCursorPos(ImVec2(cPos.x + 16 * scale, cPos.y + 32 * scale));
-                BindButton("C-Down", pads[0].button & BTN_CDOWN);
-                ImGui::EndGroup();
-
-                ImGui::SameLine();
-
-                ImGui::BeginGroup();
-                const ImVec2 sPos = ImGui::GetCursorPos();
-                ImGui::SetCursorPos(ImVec2(sPos.x + 4, sPos.y - 20 * scale));
-                BindButton("Z-Btn", pads[0].button & BTN_Z);
-                ImGui::SetCursorPos(ImVec2(sPos.x + 22, sPos.y + 16 * scale));
-                BindButton("Start-Btn", pads[0].button & BTN_START);
-                ImGui::EndGroup();
-
-                ImGui::SameLine();
-
-                ImGui::BeginGroup();
-                const ImVec2 bPos = ImGui::GetCursorPos();
-                ImGui::SetCursorPos(ImVec2(bPos.x + 20 * scale, bPos.y - 20 * scale));
-                BindButton("R-Btn", pads[0].button & BTN_R);
-                ImGui::SetCursorPos(ImVec2(bPos.x + 12 * scale, bPos.y + 8 * scale));
-                BindButton("B-Btn", pads[0].button & BTN_B);
-                ImGui::SetCursorPos(ImVec2(bPos.x + 28 * scale, bPos.y + 24 * scale));
-                BindButton("A-Btn", pads[0].button & BTN_A);
-                ImGui::EndGroup();
-
-                ImGui::End();
-            }
+        ImVec2 main_pos = ImGui::GetWindowPos();
+        main_pos.x -= top_left_pos.x;
+        main_pos.y -= top_left_pos.y;
+        ImVec2 size = ImGui::GetContentRegionAvail();
+        ImVec2 pos = ImVec2(0, 0);
+        gfx_current_dimensions.width = size.x * gfx_current_dimensions.internal_mul;
+        gfx_current_dimensions.height = size.y * gfx_current_dimensions.internal_mul;
+        gfx_current_game_window_viewport.x = main_pos.x;
+        gfx_current_game_window_viewport.y = main_pos.y;
+        gfx_current_game_window_viewport.width = size.x;
+        gfx_current_game_window_viewport.height = size.y;
+        if (Game::Settings.debug.n64mode) {
+            gfx_current_dimensions.width = 320;
+            gfx_current_dimensions.height = 240;
+            const int sw = size.y * 320 / 240;
+            gfx_current_game_window_viewport.x += (size.x - sw) / 2;
+            gfx_current_game_window_viewport.width = sw;
+            pos = ImVec2(size.x / 2 - sw / 2, 0);
+            size = ImVec2(sw, size.y);
         }
+    }
 
+    void DrawFramebufferAndGameInput() {
+         ImVec2 main_pos = ImGui::GetWindowPos();
+         ImVec2 size = ImGui::GetContentRegionAvail();
+         ImVec2 pos = ImVec2(0, 0);
+         if (Game::Settings.debug.n64mode) {
+             const int sw = size.y * 320 / 240;
+             pos = ImVec2(size.x / 2 - sw / 2, 0);
+             size = ImVec2(sw, size.y);
+         }
+         std::string fb_str = SohUtils::getEnvironmentVar("framebuffer");
+         if (!fb_str.empty()) {
+             uintptr_t fbuf = (uintptr_t)std::stoull(fb_str);
+             //ImGui::ImageSimple(reinterpret_cast<ImTextureID>(fbuf), pos, size);
+             ImGui::SetCursorPos(pos);
+             ImGui::Image(reinterpret_cast<ImTextureID>(fbuf), size);
+         }
+
+         ImGui::End();
+
+         const float scale = Game::Settings.controller.input_scale;
+         ImVec2 BtnPos = ImVec2(160 * scale, 85 * scale);
+
+         if (Game::Settings.controller.input_enabled) {
+             ImGui::SetNextWindowSize(BtnPos);
+             ImGui::SetNextWindowPos(ImVec2(main_pos.x + size.x - BtnPos.x - 20, main_pos.y + size.y - BtnPos.y - 20));
+
+             if (pads != nullptr && ImGui::Begin("Game Buttons", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoBackground)) {
+                 ImGui::SetCursorPosY(32 * scale);
+
+                 ImGui::BeginGroup();
+                 const ImVec2 cPos = ImGui::GetCursorPos();
+                 ImGui::SetCursorPos(ImVec2(cPos.x + 10 * scale, cPos.y - 20 * scale));
+                 BindButton("L-Btn", pads[0].button & BTN_L);
+                 ImGui::SetCursorPos(ImVec2(cPos.x + 16 * scale, cPos.y));
+                 BindButton("C-Up", pads[0].button & BTN_CUP);
+                 ImGui::SetCursorPos(ImVec2(cPos.x, cPos.y + 16 * scale));
+                 BindButton("C-Left", pads[0].button & BTN_CLEFT);
+                 ImGui::SetCursorPos(ImVec2(cPos.x + 32 * scale, cPos.y + 16 * scale));
+                 BindButton("C-Right", pads[0].button & BTN_CRIGHT);
+                 ImGui::SetCursorPos(ImVec2(cPos.x + 16 * scale, cPos.y + 32 * scale));
+                 BindButton("C-Down", pads[0].button & BTN_CDOWN);
+                 ImGui::EndGroup();
+
+                 ImGui::SameLine();
+
+                 ImGui::BeginGroup();
+                 const ImVec2 sPos = ImGui::GetCursorPos();
+                 ImGui::SetCursorPos(ImVec2(sPos.x + 21, sPos.y - 20 * scale));
+                 BindButton("Z-Btn", pads[0].button & BTN_Z);
+                 ImGui::SetCursorPos(ImVec2(sPos.x + 22, sPos.y + 16 * scale));
+                 BindButton("Start-Btn", pads[0].button & BTN_START);
+                 ImGui::EndGroup();
+
+                 ImGui::SameLine();
+
+                 ImGui::BeginGroup();
+                 const ImVec2 bPos = ImGui::GetCursorPos();
+                 ImGui::SetCursorPos(ImVec2(bPos.x + 20 * scale, bPos.y - 20 * scale));
+                 BindButton("R-Btn", pads[0].button & BTN_R);
+                 ImGui::SetCursorPos(ImVec2(bPos.x + 12 * scale, bPos.y + 8 * scale));
+                 BindButton("B-Btn", pads[0].button & BTN_B);
+                 ImGui::SetCursorPos(ImVec2(bPos.x + 28 * scale, bPos.y + 24 * scale));
+                 BindButton("A-Btn", pads[0].button & BTN_A);
+                 ImGui::EndGroup();
+
+                 ImGui::End();
+             }
+         }
+     }
+
+    void Render() {
         console->Draw();
 
         ImGui::Render();
@@ -663,6 +921,13 @@ namespace SohImGui {
         if (UseViewports()) {
             ImGui::UpdatePlatformWindows();
             ImGui::RenderPlatformWindowsDefault();
+        }
+    }
+
+    void CancelFrame() {
+        ImGui::EndFrame();
+        if (UseViewports()) {
+            ImGui::UpdatePlatformWindows();
         }
     }
 

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -290,7 +290,6 @@ namespace SohImGui {
             pads = static_cast<OSContPad*>(ev->baseArgs["cont_pad"]);
         } });
         Game::InitSettings();
-        //LoadHUDColors();
     }
 
     void Update(EventImpl event) {
@@ -445,8 +444,14 @@ namespace SohImGui {
                 ImGui::Text("Gameplay");
                 ImGui::Separator();
 
-                if (ImGui::Checkbox("Fast Text", &Game::Settings.enhancements.fast_text)) {
-                    CVar_SetS32("gFastText", Game::Settings.enhancements.fast_text);
+                ImGui::Text("Text Speed: %dx", Game::Settings.enhancements.text_speed);
+                if (ImGui::SliderInt("##TEXTSPEED", &Game::Settings.enhancements.text_speed, 1, 5, "")) {
+                    CVar_SetS32("gTextSpeed", Game::Settings.enhancements.text_speed);
+                    needs_save = true;
+                }
+
+                if (ImGui::Checkbox("Skip Text", &Game::Settings.enhancements.skip_text)) {
+                    CVar_SetS32("gSkipText", Game::Settings.enhancements.skip_text);
                     needs_save = true;
                 }
 
@@ -504,6 +509,11 @@ namespace SohImGui {
 
                 ImGui::Text("Debug");
                 ImGui::Separator();
+
+                if (ImGui::Checkbox("Hide build infos", &Game::Settings.debug.buildinfos)) {
+                    CVar_SetS32("gBuildInfos", Game::Settings.debug.buildinfos);
+                    needs_save = true;
+                }
 
                 if (ImGui::Checkbox("Debug Mode", &Game::Settings.cheats.debug_mode)) {
                     CVar_SetS32("gDebugEnabled", Game::Settings.cheats.debug_mode);

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -50,8 +50,13 @@ namespace SohImGui {
     extern Console* console;
     void Init(WindowImpl window_impl);
     void Update(EventImpl event);
-    void Draw(void);
+    int ClampFloatToInt(float value, int min, int max);
+    void DrawMainMenuAndCalculateGameSize(void);
+    void DrawFramebufferAndGameInput(void);
+    void Render(void);
+    void CancelFrame(void);
     void ShowCursor(bool hide, Dialogues w);
     void BindCmd(const std::string& cmd, CommandEntry entry);
     void* GetTextureByID(int id);
+    void LoadHUDColors();
 }

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -290,6 +290,10 @@ namespace Ship {
         //gfx_set_framedivisor(0);
     }
 
+    void Window::GetPixelDepthPrepare(float x, float y) {
+        gfx_get_pixel_depth_prepare(x, y);
+    }
+
     uint16_t Window::GetPixelDepth(float x, float y) {
         return gfx_get_pixel_depth(x, y);
     }

--- a/libultraship/libultraship/Window.h
+++ b/libultraship/libultraship/Window.h
@@ -20,6 +20,7 @@ namespace Ship {
 			void Init();
 			void RunCommands(Gfx* Commands);
 			void SetFrameDivisor(int divisor);
+			void GetPixelDepthPrepare(float x, float y);
 			uint16_t GetPixelDepth(float x, float y);
 			void ToggleFullscreen();
 			void SetFullscreen(bool bIsFullscreen);
@@ -50,4 +51,3 @@ namespace Ship {
 			uint32_t dwHeight;
 	};
 }
-

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -977,6 +977,7 @@ void LightContext_RemoveLight(GlobalContext* globalCtx, LightContext* lightCtx, 
 Lights* Lights_NewAndDraw(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambientB, u8 numLights, u8 r, u8 g,
                           u8 b, s8 x, s8 y, s8 z);
 Lights* Lights_New(GraphicsContext* gfxCtx, u8 ambientR, u8 ambientG, u8 ambientB);
+void Lights_GlowCheckPrepare(GlobalContext* globalCtx);
 void Lights_GlowCheck(GlobalContext* globalCtx);
 void Lights_DrawGlow(GlobalContext* globalCtx);
 void ZeldaArena_CheckPointer(void* ptr, size_t size, const char* name, const char* action);

--- a/soh/include/z64interface.h
+++ b/soh/include/z64interface.h
@@ -28,7 +28,6 @@
  * env color for the base hearts is the purple-ish outline, while the env color for the double defense
  * hearts is the red color of the hearts.
  */
-
 #define HEARTS_PRIM_R 255
 #define HEARTS_PRIM_G 70
 #define HEARTS_PRIM_B 50

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -30,6 +30,9 @@ void BootCommands_Init()
     CVar_RegisterS32("gNewDrops", 0);
     CVar_RegisterS32("gVisualAgony", 0);
     CVar_RegisterS32("gUniformLR", 0);
+    CVar_RegisterS32("gN64Colors", 1);
+    CVar_RegisterS32("gGameCubeColors", 0);
+    CVar_RegisterS32("gCustomColors", 0);
 }
 
 //void BootCommands_ParseBootArgs(char* str)

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -977,7 +977,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
     s32 doubleWidth;
     s32 titleY;
     s32 titleSecondY;
-    s32 textureLanguageOffset;
 
     if (titleCtx->alpha != 0) {
         width = titleCtx->width;
@@ -988,7 +987,6 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 
         OPEN_DISPS(globalCtx->state.gfxCtx, "../z_actor.c", 2824);
 
-        textureLanguageOffset = width * height * gSaveContext.language;
         height = (width * height > 0x1000) ? 0x1000 / width : height;
         titleSecondY = titleY + (height * 4);
 
@@ -996,7 +994,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         TITLE_CARD_DISP = func_80093808(TITLE_CARD_DISP);
         gDPSetPrimColor(TITLE_CARD_DISP++, 0, 0, (u8)titleCtx->intensity, (u8)titleCtx->intensity, (u8)titleCtx->intensity, (u8)titleCtx->alpha);
 
-        gDPLoadTextureBlock(TITLE_CARD_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0,
+        gDPLoadTextureBlock(TITLE_CARD_DISP++, (uintptr_t)titleCtx->texture, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0,
         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
         gSPTextureRectangle(TITLE_CARD_DISP++, titleX, titleY, ((doubleWidth * 2) + titleX) - 4, titleY + (height * 4) - 1, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
@@ -1006,7 +1004,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
 
         // If texture is bigger than 0x1000, display the rest
         if (height > 0) {
-            gDPLoadTextureBlock(TITLE_CARD_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + 0x1000,
+            gDPLoadTextureBlock(TITLE_CARD_DISP++, (uintptr_t)titleCtx->texture + 0x1000,
                                 G_IM_FMT_IA,
                                 G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -142,6 +142,18 @@ void HealthMeter_Init(GlobalContext* globalCtx) {
     sHeartsDDEnv[0][0] = sHeartsDDEnv[1][0] = HEARTS_DD_ENV_R;
     sHeartsDDEnv[0][1] = sHeartsDDEnv[1][1] = HEARTS_DD_ENV_G;
     sHeartsDDEnv[0][2] = sHeartsDDEnv[1][2] = HEARTS_DD_ENV_B;
+
+    if (CVar_GetS32("gCustomColors", 0) != 0) {//Load custom colors !
+        interfaceCtx->heartsPrimR[0] = CVar_GetInt("gCCHeartsPrimR", 220);
+        interfaceCtx->heartsPrimG[0] = CVar_GetInt("gCCHeartsPrimG", 10);
+        interfaceCtx->heartsPrimB[0] = CVar_GetInt("gCCHeartsPrimB", 10);
+        interfaceCtx->heartsPrimR[1] = CVar_GetInt("gCCHeartsPrimR", 220);
+        interfaceCtx->heartsPrimG[1] = CVar_GetInt("gCCHeartsPrimG", 10);
+        interfaceCtx->heartsPrimB[1] = CVar_GetInt("gCCHeartsPrimB", 10);
+        sHeartsDDPrim[0][0] = sHeartsDDPrim[1][0] = CVar_GetInt("gDDCCHeartsPrimR", 220);
+        sHeartsDDPrim[0][1] = sHeartsDDPrim[1][1] = CVar_GetInt("gDDCCHeartsPrimG", 10);
+        sHeartsDDPrim[0][2] = sHeartsDDPrim[1][2] = CVar_GetInt("gDDCCHeartsPrimB", 10);
+    }
 }
 
 void HealthMeter_Update(GlobalContext* globalCtx) {
@@ -172,9 +184,15 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
 
     ddFactor = factor;
 
-    interfaceCtx->heartsPrimR[0] = HEARTS_PRIM_R;
-    interfaceCtx->heartsPrimG[0] = HEARTS_PRIM_G;
-    interfaceCtx->heartsPrimB[0] = HEARTS_PRIM_B;
+    if (CVar_GetS32("gCustomColors", 0) != 0) {//Required for runtime colors change.
+        interfaceCtx->heartsPrimR[0] = CVar_GetInt("gCCHeartsPrimR", 220);
+        interfaceCtx->heartsPrimG[0] = CVar_GetInt("gCCHeartsPrimG", 10);
+        interfaceCtx->heartsPrimB[0] = CVar_GetInt("gCCHeartsPrimB", 10);
+    } else {
+        interfaceCtx->heartsPrimR[0] = HEARTS_PRIM_R;
+        interfaceCtx->heartsPrimG[0] = HEARTS_PRIM_G;
+        interfaceCtx->heartsPrimB[0] = HEARTS_PRIM_B;
+    }
 
     interfaceCtx->heartsEnvR[0] = HEARTS_ENV_R;
     interfaceCtx->heartsEnvG[0] = HEARTS_ENV_G;
@@ -192,15 +210,20 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     gFactor = sHeartsPrimFactors[0][1] * factor;
     bFactor = sHeartsPrimFactors[0][2] * factor;
 
-    interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + HEARTS_PRIM_R) & 0xFF;
-    interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + HEARTS_PRIM_G) & 0xFF;
-    interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + HEARTS_PRIM_B) & 0xFF;
+    if (CVar_GetS32("gCustomColors", 0) != 0) {//Required for runtime colors change. (that when the heart grow and shrink color)
+        interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + CVar_GetInt("gCCHeartsPrimR", 220)) & 0xFF;
+        interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + CVar_GetInt("gCCHeartsPrimG", 10)) & 0xFF;
+        interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + CVar_GetInt("gCCHeartsPrimB", 10)) & 0xFF;
+    } else {
+        interfaceCtx->beatingHeartPrim[0] = (u8)(rFactor + HEARTS_PRIM_R) & 0xFF;
+        interfaceCtx->beatingHeartPrim[1] = (u8)(gFactor + HEARTS_PRIM_G) & 0xFF;
+        interfaceCtx->beatingHeartPrim[2] = (u8)(bFactor + HEARTS_PRIM_B) & 0xFF;
+    }
 
     rFactor = sHeartsEnvFactors[0][0] * factor;
     gFactor = sHeartsEnvFactors[0][1] * factor;
     bFactor = sHeartsEnvFactors[0][2] * factor;
 
-    if (1) {}
     ddType = type;
 
     interfaceCtx->beatingHeartEnv[0] = (u8)(rFactor + HEARTS_ENV_R) & 0xFF;
@@ -215,9 +238,15 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     sHeartsDDEnv[0][1] = HEARTS_DD_ENV_G;
     sHeartsDDEnv[0][2] = HEARTS_DD_ENV_B;
 
-    sHeartsDDPrim[1][0] = sHeartsDDPrimColors[ddType][0];
-    sHeartsDDPrim[1][1] = sHeartsDDPrimColors[ddType][1];
-    sHeartsDDPrim[1][2] = sHeartsDDPrimColors[ddType][2];
+    if (CVar_GetS32("gCustomColors", 0) != 0) {//Same as abose (DD stand for Double Defense)
+        sHeartsDDPrim[0][0] = CVar_GetInt("gDDCCHeartsPrimR", 220);
+        sHeartsDDPrim[0][1] = CVar_GetInt("gDDCCHeartsPrimG", 0);
+        sHeartsDDPrim[0][2] = CVar_GetInt("gDDCCHeartsPrimB", 0);
+    } else {
+        sHeartsDDPrim[0][0] = HEARTS_DD_PRIM_R;
+        sHeartsDDPrim[0][1] = HEARTS_DD_PRIM_G;
+        sHeartsDDPrim[0][2] = HEARTS_DD_PRIM_B;
+    }
 
     sHeartsDDEnv[1][0] = sHeartsDDEnvColors[ddType][0];
     sHeartsDDEnv[1][1] = sHeartsDDEnvColors[ddType][1];
@@ -227,9 +256,15 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     gFactor = sHeartsDDPrimFactors[ddType][1] * ddFactor;
     bFactor = sHeartsDDPrimFactors[ddType][2] * ddFactor;
 
-    sBeatingHeartsDDPrim[0] = (u8)(rFactor + HEARTS_DD_PRIM_R) & 0xFF;
-    sBeatingHeartsDDPrim[1] = (u8)(gFactor + HEARTS_DD_PRIM_G) & 0xFF;
-    sBeatingHeartsDDPrim[2] = (u8)(bFactor + HEARTS_DD_PRIM_B) & 0xFF;
+    if (CVar_GetS32("gCustomColors", 0) != 0) {//Since that in Update() runtime color change will work like that :)
+        sBeatingHeartsDDPrim[0] = (u8)(rFactor + CVar_GetInt("gDDCCHeartsPrimR", 220)) & 0xFF;
+        sBeatingHeartsDDPrim[1] = (u8)(gFactor + CVar_GetInt("gDDCCHeartsPrimG", 0)) & 0xFF;
+        sBeatingHeartsDDPrim[2] = (u8)(bFactor + CVar_GetInt("gDDCCHeartsPrimB", 0)) & 0xFF;
+    } else {
+        sBeatingHeartsDDPrim[0] = (u8)(rFactor + HEARTS_DD_PRIM_R) & 0xFF;
+        sBeatingHeartsDDPrim[1] = (u8)(gFactor + HEARTS_DD_PRIM_G) & 0xFF;
+        sBeatingHeartsDDPrim[2] = (u8)(bFactor + HEARTS_DD_PRIM_B) & 0xFF;
+    }
 
     rFactor = sHeartsDDEnvFactors[ddType][0] * ddFactor;
     gFactor = sHeartsDDEnvFactors[ddType][1] * ddFactor;

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -410,6 +410,9 @@ void Map_InitData(GlobalContext* globalCtx, s16 room) {
                 memcpy(globalCtx->interfaceCtx.mapSegment, ResourceMgr_LoadTexByName(minimapTableOW[sEntranceIconMapIndex]), gMapData->owMinimapTexSize[mapIndex]);
 
             interfaceCtx->unk_258 = mapIndex;
+            OPEN_DISPS(globalCtx->state.gfxCtx, "../z_map_exp.c", 626);
+            gSPInvalidateTexCache(OVERLAY_DISP++, interfaceCtx->mapSegment);
+            CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_map_exp.c", 782);
             break;
         case SCENE_YDAN:
         case SCENE_DDAN:
@@ -444,6 +447,9 @@ void Map_InitData(GlobalContext* globalCtx, s16 room) {
             R_COMPASS_OFFSET_Y = gMapData->roomCompassOffsetY[mapIndex][room];
             Map_SetFloorPalettesData(globalCtx, VREG(30));
             //osSyncPrintf("ＭＡＰ 各階ＯＮチェック\n"); // "MAP Individual Floor ON Check"
+            OPEN_DISPS(globalCtx->state.gfxCtx, "../z_map_exp.c", 626);
+            gSPInvalidateTexCache(OVERLAY_DISP++, interfaceCtx->mapSegment);
+            CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_map_exp.c", 782);
             break;
     }
 }
@@ -653,9 +659,11 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                       TEXEL0, 0, PRIMITIVE, 0);
 
                     if (CHECK_DUNGEON_ITEM(DUNGEON_MAP, mapIndex)) {
-                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 100, 255, 255, interfaceCtx->minimapAlpha);
-
-                        gSPInvalidateTexCache(OVERLAY_DISP++, interfaceCtx->mapSegment);
+                        if (CVar_GetS32("gCustomColors", 0) != 0) { //Dungeon minimap
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCMinimapPrimR", 255), CVar_GetInt("gCCMinimapPrimG", 255), CVar_GetInt("gCCMinimapPrimB", 255), interfaceCtx->magicAlpha);
+                        } else {
+                            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 100, 255, 255, interfaceCtx->minimapAlpha);
+                        }
                         gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->mapSegment, G_IM_FMT_I, 96, 85, 0,
                                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                                G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -710,7 +718,11 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                     func_80094520(globalCtx->state.gfxCtx);
 
                     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
+                    if (CVar_GetS32("gCustomColors", 0) != 0) {//Overworld minimap
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCMinimapPrimR", 255), CVar_GetInt("gCCMinimapPrimG", 255), CVar_GetInt("gCCMinimapPrimB", 255), interfaceCtx->magicAlpha);
+                    } else {
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
+                    }
 
                     gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->mapSegment, G_IM_FMT_IA,
                                            gMapData->owMinimapWidth[mapIndex], gMapData->owMinimapHeight[mapIndex], 0,
@@ -723,6 +735,10 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                            (oWMiniMapX + gMapData->owMinimapWidth[mapIndex]) << 2,
                                            (R_OW_MINIMAP_Y + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, 0,
                                             0, 1 << 10, 1 << 10);
+
+                    if (CVar_GetS32("gCustomColors", 0) != 1) {//This need to be added else it will color dungeon entrance icon too. (it re-init prim color to default color)
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
+                    }
 
                     if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) &&
                          (globalCtx->sceneNum != SCENE_SPOT08)) ||

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -94,33 +94,20 @@ void Message_ResetOcarinaNoteState(void) {
     sOcarinaNotesAlphaValues[0] = sOcarinaNotesAlphaValues[1] = sOcarinaNotesAlphaValues[2] =
         sOcarinaNotesAlphaValues[3] = sOcarinaNotesAlphaValues[4] = sOcarinaNotesAlphaValues[5] =
             sOcarinaNotesAlphaValues[6] = sOcarinaNotesAlphaValues[7] = sOcarinaNotesAlphaValues[8] = 0;
-    if (CVar_GetS32("gN64Color", 0) !=0) {
-		sOcarinaNoteAPrimR = 80;
-		sOcarinaNoteAPrimG = 150;
-		sOcarinaNoteAPrimB = 255;
-		sOcarinaNoteAEnvR = 10;
-		sOcarinaNoteAEnvG = 10;
-		sOcarinaNoteAEnvB = 10;
-		sOcarinaNoteCPrimR = 255;
-		sOcarinaNoteCPrimG = 255;
-		sOcarinaNoteCPrimB = 50;
-		sOcarinaNoteCEnvR = 10;
-		sOcarinaNoteCEnvG = 10;
-		sOcarinaNoteCEnvB = 10;
-    } else {
-		sOcarinaNoteAPrimR = 80;
-		sOcarinaNoteAPrimG = 255;
-		sOcarinaNoteAPrimB = 150;
-		sOcarinaNoteAEnvR = 10;
-		sOcarinaNoteAEnvG = 10;
-		sOcarinaNoteAEnvB = 10;
-		sOcarinaNoteCPrimR = 255;
-		sOcarinaNoteCPrimG = 255;
-		sOcarinaNoteCPrimB = 50;
-		sOcarinaNoteCEnvR = 10;
-		sOcarinaNoteCEnvG = 10;
-		sOcarinaNoteCEnvB = 10;
-    }
+
+    sOcarinaNoteAPrimR = 80;
+    sOcarinaNoteAPrimG = 255;
+    sOcarinaNoteAPrimB = 150;
+    sOcarinaNoteAEnvR = 10;
+    sOcarinaNoteAEnvG = 10;
+    sOcarinaNoteAEnvB = 10;
+    sOcarinaNoteCPrimR = 255;
+    sOcarinaNoteCPrimG = 255;
+    sOcarinaNoteCPrimB = 50;
+    sOcarinaNoteCEnvR = 10;
+    sOcarinaNoteCEnvG = 10;
+    sOcarinaNoteCEnvB = 10;
+    
 
 }
 
@@ -148,7 +135,7 @@ void Message_UpdateOcarinaGame(GlobalContext* globalCtx) {
 u8 Message_ShouldAdvance(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     if (CHECK_BTN_ALL(input->press.button, BTN_A) || isB_Held || CHECK_BTN_ALL(input->press.button, BTN_CUP)) {
@@ -160,7 +147,7 @@ u8 Message_ShouldAdvance(GlobalContext* globalCtx) {
 u8 Message_ShouldAdvanceSilent(GlobalContext* globalCtx) {
     Input* input = &globalCtx->state.input[0];
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B)
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     return CHECK_BTN_ALL(input->press.button, BTN_A) || isB_Held || CHECK_BTN_ALL(input->press.button, BTN_CUP);
@@ -374,17 +361,9 @@ void Message_FindCreditsMessage(GlobalContext* globalCtx, u16 textId) {
         if (messageTableEntry->textId == textId) {
             foundSeg = messageTableEntry->segment;
             font->charTexBuf[0] = messageTableEntry->typePos;
-            messageTableEntry++;
             nextSeg = messageTableEntry->segment;
             font->msgOffset = messageTableEntry->segment;
             font->msgLength = messageTableEntry->msgSize;
-		
-            char *CheckedSTR; //Temp char to hold our checked string
-            CheckedSTR = strcasestr(messageTableEntry->segment, "Deleted"); //Check if word Deleted is present
-            if (CheckedSTR) { //If found
-              font->msgOffset = ""; //Remove the segment (aka string to be displayed)
-              font->msgLength = 0x0000; //and to be sure nothing is show make length to zero.
-            }
 		
             // "Message found!!!"
             osSyncPrintf(" メッセージが,見つかった！！！ = %x  (data=%x) (data0=%x) (data1=%x) (data2=%x) (data3=%x)\n",
@@ -495,33 +474,54 @@ void Message_DrawTextboxIcon(GlobalContext* globalCtx, Gfx** p, s16 x, s16 y) {
 		{ 0, 0, 0 },
 		{ 0, 255, 130 },
 	};
-	if (CVar_GetS32("gN64Color", 0) !=0) {
-		sIconPrimColors[0][0] = 4;
-		sIconPrimColors[0][1] = 84;
-		sIconPrimColors[0][2] = 204;
-		sIconPrimColors[1][0] = 45;
-		sIconPrimColors[1][1] = 125;
-		sIconPrimColors[1][2] = 255;
-		sIconEnvColors[0][0] = 0;
-		sIconEnvColors[0][1] = 0;
-		sIconEnvColors[0][2] = 0;
-		sIconEnvColors[1][0] = 0;
-		sIconEnvColors[1][1] = 70;
-		sIconEnvColors[1][2] = 255;
-	};
     static s16 sIconPrimR = 0;
     static s16 sIconPrimG = 200;
     static s16 sIconPrimB = 80;
-    if (CVar_GetS32("gN64Color", 0) !=0) {
-		sIconPrimR = 0;
-		sIconPrimG = 70;
-		sIconPrimB = 255;
-    }
     static s16 sIconFlashTimer = 12;
     static s16 sIconFlashColorIdx = 0;
     static s16 sIconEnvR = 0;
     static s16 sIconEnvG = 0;
     static s16 sIconEnvB = 0;
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      sIconPrimColors[0][0] = 4;
+      sIconPrimColors[0][1] = 84;
+      sIconPrimColors[0][2] = 204;
+      sIconPrimColors[1][0] = 45;
+      sIconPrimColors[1][1] = 125;
+      sIconPrimColors[1][2] = 255;
+      sIconEnvColors[0][0] = 0;
+      sIconEnvColors[0][1] = 0;
+      sIconEnvColors[0][2] = 0;
+      sIconEnvColors[1][0] = 0;
+      sIconEnvColors[1][1] = 70;
+      sIconEnvColors[1][2] = 255;
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {//Probably could emptied I need some testing there, I will do it later.
+      sIconPrimColors[0][0] = 4;
+      sIconPrimColors[0][1] = 200;
+      sIconPrimColors[0][2] = 80;
+      sIconPrimColors[1][0] = 50;
+      sIconPrimColors[1][1] = 255;
+      sIconPrimColors[1][2] = 130;
+      sIconEnvColors[0][0] = 0;
+      sIconEnvColors[0][1] = 0;
+      sIconEnvColors[0][2] = 0;
+      sIconEnvColors[1][0] = 0;
+      sIconEnvColors[1][1] = 255;
+      sIconEnvColors[1][2] = 130;
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      sIconPrimColors[0][0] = (CVar_GetInt("gCCABtnPrimR", 4)/255)*80;
+      sIconPrimColors[0][1] = (CVar_GetInt("gCCABtnPrimG", 200)/255)*80;
+      sIconPrimColors[0][2] = (CVar_GetInt("gCCABtnPrimB", 80)/255)*80;
+      sIconPrimColors[1][0] = CVar_GetInt("gCCABtnPrimR", 50);
+      sIconPrimColors[1][1] = CVar_GetInt("gCCABtnPrimG", 255);
+      sIconPrimColors[1][2] = CVar_GetInt("gCCABtnPrimB", 130);
+      sIconEnvColors[0][0] = 0;
+      sIconEnvColors[0][1] = 0;
+      sIconEnvColors[0][2] = 0;
+      sIconEnvColors[1][0] = 10;
+      sIconEnvColors[1][1] = 10;
+      sIconEnvColors[1][2] = 10;
+    }
     MessageContext* msgCtx = &globalCtx->msgCtx;
     Font* font = &msgCtx->font;
     Gfx* gfx = *p;
@@ -598,6 +598,7 @@ void Message_DrawTextboxIcon(GlobalContext* globalCtx, Gfx** p, s16 x, s16 y) {
 
     gDPSetCombineLERP(gfx++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE,
                       ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+
 
     gDPSetPrimColor(gfx++, 0, 0, sIconPrimR, sIconPrimG, sIconPrimB, 255);
     gDPSetEnvColor(gfx++, sIconEnvR, sIconEnvG, sIconEnvB, 255);
@@ -966,7 +967,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                         }
                     }
                     i = j - 1;
-                    msgCtx->textDrawPos = i + 1;
+                    msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
 
                     if (character) {}
                 }
@@ -1076,7 +1077,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
                 msgCtx->textDelay = msgCtx->msgBufDecoded[++i];
                 break;
             case MESSAGE_UNSKIPPABLE:
-                msgCtx->textUnskippable = CVar_GetS32("gFastText", 0) != 1;
+                msgCtx->textUnskippable = CVar_GetS32("gSkipText", 0) != 1;
                 break;
             case MESSAGE_TWO_CHOICE:
                 msgCtx->textboxEndType = TEXTBOX_ENDTYPE_2_CHOICE;
@@ -1159,7 +1160,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        msgCtx->textDrawPos = i + 1;
+        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;
@@ -1995,21 +1996,6 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
         { 10, 10, 10 },
         { 110, 110, 50 },
     };
-    if (CVar_GetS32("gN64Color", 0) !=0) {
-    	sOcarinaNoteAPrimColors[0][0] = 80;
-    	sOcarinaNoteAPrimColors[0][1] = 150;
-    	sOcarinaNoteAPrimColors[0][2] = 255;
-    	sOcarinaNoteAPrimColors[1][0] = 100;
-    	sOcarinaNoteAPrimColors[1][1] = 200;
-    	sOcarinaNoteAPrimColors[1][2] = 255;
-
-    	sOcarinaNoteAEnvColors[0][0] = 10;
-    	sOcarinaNoteAEnvColors[0][1] = 10;
-    	sOcarinaNoteAEnvColors[0][2] = 10;
-    	sOcarinaNoteAEnvColors[1][0] = 50;
-    	sOcarinaNoteAEnvColors[1][1] = 50;
-    	sOcarinaNoteAEnvColors[1][2] = 255;
-    }
     static s16 sOcarinaNoteFlashTimer = 12;
     static s16 sOcarinaNoteFlashColorIdx = 1;
     static s16 sOcarinaSongFanfares[] = {
@@ -2049,7 +2035,7 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
         gDPSetCombineLERP(gfx++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE,
                           0);
 
-            bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B)
+            bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B)
                                                          : CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_B);
 
         switch (msgCtx->msgMode) {
@@ -2322,14 +2308,6 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
                     sOcarinaNoteCEnvB = sOcarinaNoteCEnvColors[sOcarinaNoteFlashColorIdx][2];
                     sOcarinaNoteFlashTimer = 3;
                     sOcarinaNoteFlashColorIdx ^= 1;
-                    if (CVar_GetS32("gN64Color", 0) !=0) {
-		                sOcarinaNoteAPrimR = 70;
-		                sOcarinaNoteAPrimG = 70;
-		                sOcarinaNoteAPrimB = 255;
-		                sOcarinaNoteAEnvR = 50;
-		                sOcarinaNoteAEnvG = 50;
-		                sOcarinaNoteAEnvB = 255;
-					}
                 }
 
                 msgCtx->stateTimer--;
@@ -2933,15 +2911,27 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
 
                     gDPPipeSync(gfx++);
                     if (sOcarinaNoteBuf[i] == OCARINA_NOTE_A) {
+                      if (CVar_GetS32("gN64Colors", 0) != 0) { //A buttons :)
+                        gDPSetPrimColor(gfx++, 0, 0, 80, 150, 255, sOcarinaNotesAlphaValues[i]);
+                        gDPSetEnvColor(gfx++, 100, 200, 255, 0);
+                      } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
                         gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteAPrimR, sOcarinaNoteAPrimG, sOcarinaNoteAPrimB, sOcarinaNotesAlphaValues[i]);
-                        if (CVar_GetS32("gN64Color", 0) !=0) {
-                        	gDPSetPrimColor(gfx++, 0, 0, 81, 135, 221, sOcarinaNotesAlphaValues[i]);
-                        }
                         gDPSetEnvColor(gfx++, sOcarinaNoteAEnvR, sOcarinaNoteAEnvG, sOcarinaNoteAEnvB, 0);
+                      } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                        gDPSetPrimColor(gfx++, 0, 0, CVar_GetInt("gCCABtnPrimR", 0), CVar_GetInt("gCCABtnPrimG", 0), CVar_GetInt("gCCABtnPrimB", 0), sOcarinaNotesAlphaValues[i]);
+                        gDPSetEnvColor(gfx++, CVar_GetInt("gCCABtnPrimR", 0)/2, CVar_GetInt("gCCABtnPrimG", 0)/2, CVar_GetInt("gCCABtnPrimB", 0)/2, 0);
+                      }
                     } else {
-                        gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCPrimR, sOcarinaNoteCPrimG, sOcarinaNoteCPrimB,
-                                        sOcarinaNotesAlphaValues[i]);
+                       if (CVar_GetS32("gN64Colors", 0) != 0) { //C buttons :)
+                        gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCPrimR, sOcarinaNoteCPrimG, sOcarinaNoteCPrimB, sOcarinaNotesAlphaValues[i]);
                         gDPSetEnvColor(gfx++, sOcarinaNoteCEnvR, sOcarinaNoteCEnvG, sOcarinaNoteCEnvB, 0);
+                      } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                        gDPSetPrimColor(gfx++, 0, 0, sOcarinaNoteCPrimR, sOcarinaNoteCPrimG, sOcarinaNoteCPrimB, sOcarinaNotesAlphaValues[i]);
+                        gDPSetEnvColor(gfx++, sOcarinaNoteCEnvR, sOcarinaNoteCEnvG, sOcarinaNoteCEnvB, 0);
+                      } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                        gDPSetPrimColor(gfx++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 0), CVar_GetInt("gCCCBtnPrimG", 0), CVar_GetInt("gCCCBtnPrimB", 0), sOcarinaNotesAlphaValues[i]);
+                        gDPSetEnvColor(gfx++, CVar_GetInt("gCCCBtnPrimR", 0)/2, CVar_GetInt("gCCCBtnPrimG", 0)/2, CVar_GetInt("gCCCBtnPrimB", 0)/2, 0);
+                      }
                     }
 
                     gDPLoadTextureBlock(gfx++, sOcarinaNoteTextures[sOcarinaNoteBuf[i]], G_IM_FMT_IA, G_IM_SIZ_8b, 16,
@@ -3100,7 +3090,7 @@ void Message_Update(GlobalContext* globalCtx) {
         return;
     }
 
-    bool isB_Held = CVar_GetS32("gFastText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B) && !sTextboxSkipped
+    bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(input->cur.button, BTN_B) && !sTextboxSkipped
                                                      : CHECK_BTN_ALL(input->press.button, BTN_B);
 
     switch (msgCtx->msgMode) {

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -293,11 +293,9 @@ void Message_FindMessage(GlobalContext* globalCtx, u16 textId) {
 
             if (messageTableEntry->textId == textId) {
                 foundSeg = messageTableEntry->segment;
-                //LUS_LOG(1,foundSeg);
                 font->charTexBuf[0] = messageTableEntry->typePos;
                 //messageTableEntry++;
                 nextSeg = messageTableEntry->segment;
-                //LUS_LOG(1,nextSeg);
                 font->msgOffset = messageTableEntry->segment;
                 font->msgLength = messageTableEntry->msgSize;
                 // "Message found!!!"
@@ -602,7 +600,6 @@ void Message_DrawTextboxIcon(GlobalContext* globalCtx, Gfx** p, s16 x, s16 y) {
 
     gDPSetPrimColor(gfx++, 0, 0, sIconPrimR, sIconPrimG, sIconPrimB, 255);
     gDPSetEnvColor(gfx++, sIconEnvR, sIconEnvG, sIconEnvB, 255);
-
     gDPLoadTextureBlock_4b(gfx++, iconTexture, G_IM_FMT_I, FONT_CHAR_TEX_WIDTH, FONT_CHAR_TEX_HEIGHT, 0,
                            G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                            G_TX_NOLOD);
@@ -1160,7 +1157,7 @@ void Message_DrawText(GlobalContext* globalCtx, Gfx** gfxP) {
         }
     }
     if (msgCtx->textDelayTimer == 0) {
-        msgCtx->textDrawPos = i + CVar_GetS32("gTextSpeed", 1);
+        msgCtx->textDrawPos = i + 1;
         msgCtx->textDelayTimer = msgCtx->textDelay;
     } else {
         msgCtx->textDelayTimer--;
@@ -2035,8 +2032,7 @@ void Message_DrawMain(GlobalContext* globalCtx, Gfx** p) {
         gDPSetCombineLERP(gfx++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE,
                           0);
 
-            bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B)
-                                                         : CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_B);
+        bool isB_Held = CVar_GetS32("gSkipText", 0) != 0 ? CHECK_BTN_ALL(globalCtx->state.input[0].cur.button, BTN_B) : CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_B);
 
         switch (msgCtx->msgMode) {
             case MSGMODE_TEXT_START:

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2433,6 +2433,23 @@ void Interface_UpdateMagicBar(GlobalContext* globalCtx) {
         { 255, 255, 150 },
         { 255, 255, 50 },
     };
+    if (CVar_GetS32("gCustomColors", 0) != 0) { //This will make custom color based on users selected colors.
+        sMagicBorderColors[0][0] = CVar_GetInt("gCCMagicBorderPrimR", 255);
+        sMagicBorderColors[0][1] = CVar_GetInt("gCCMagicBorderPrimG", 255);
+        sMagicBorderColors[0][2] = CVar_GetInt("gCCMagicBorderPrimB", 255);
+
+        sMagicBorderColors[1][0] = CVar_GetInt("gCCMagicBorderPrimR", 255)/2;
+        sMagicBorderColors[1][1] = CVar_GetInt("gCCMagicBorderPrimG", 255)/2;
+        sMagicBorderColors[1][2] = CVar_GetInt("gCCMagicBorderPrimB", 255)/2;
+
+        sMagicBorderColors[2][0] = CVar_GetInt("gCCMagicBorderPrimR", 255)/3;
+        sMagicBorderColors[2][1] = CVar_GetInt("gCCMagicBorderPrimG", 255)/3;
+        sMagicBorderColors[2][2] = CVar_GetInt("gCCMagicBorderPrimB", 255)/3;
+
+        sMagicBorderColors[3][0] = CVar_GetInt("gCCMagicBorderPrimR", 255)/2;
+        sMagicBorderColors[3][1] = CVar_GetInt("gCCMagicBorderPrimG", 255)/2;
+        sMagicBorderColors[3][2] = CVar_GetInt("gCCMagicBorderPrimB", 255)/2;
+    }
     static s16 sMagicBorderIndexes[] = { 0, 1, 1, 0 };
     static s16 sMagicBorderRatio = 2;
     static s16 sMagicBorderStep = 1;
@@ -2631,7 +2648,11 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         func_80094520(globalCtx->state.gfxCtx);
 
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, sMagicBorderR, sMagicBorderG, sMagicBorderB, interfaceCtx->magicAlpha);
-        gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
+        if (CVar_GetS32("gCustomColors", 0) != 0) {//Original game add color there so to prevent miss match we make it all white :)
+            gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+        } else {
+            gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
+        }
 
         OVERLAY_DISP =
             Gfx_TextureIA8(OVERLAY_DISP, gMagicBarEndTex, 8, 16, OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X),
@@ -2658,7 +2679,11 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
 
         if (gSaveContext.unk_13F0 == 4) {
             // Yellow part of the bar indicating the amount of magic to be subtracted
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 250, 250, 0, interfaceCtx->magicAlpha);
+            if (CVar_GetS32("gCustomColors", 0) != 0) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCMagicUsePrimR", 250), CVar_GetInt("gCCMagicUsePrimG", 250), CVar_GetInt("gCCMagicUsePrimB", 0), interfaceCtx->magicAlpha);
+            } else {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 250, 250, 0, interfaceCtx->magicAlpha);
+            }
 
             gDPLoadMultiBlock_4b(OVERLAY_DISP++, gMagicBarFillTex, 0, G_TX_RENDERTILE, G_IM_FMT_I, 16, 16, 0,
                                  G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
@@ -2670,16 +2695,22 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
 
             // Fill the rest of the bar with the normal magic color
             gDPPipeSync(OVERLAY_DISP++);
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2),
-                            interfaceCtx->magicAlpha);
+            if (CVar_GetS32("gCustomColors", 0) != 0) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCMagicPrimR", 0), CVar_GetInt("gCCMagicPrimG", 200), CVar_GetInt("gCCMagicPrimB", 0), interfaceCtx->magicAlpha);
+            } else {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2), interfaceCtx->magicAlpha);
+            }
 
             gSPWideTextureRectangle(OVERLAY_DISP++, rMagicFillX << 2, (magicBarY + 3) << 2,
                                 (rMagicFillX + gSaveContext.unk_13F8) << 2, (magicBarY + 10) << 2, G_TX_RENDERTILE,
                                 0, 0, 1 << 10, 1 << 10);
         } else {
             // Fill the whole bar with the normal magic color
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2),
-                            interfaceCtx->magicAlpha);
+            if (CVar_GetS32("gCustomColors", 0) != 0) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCMagicPrimR", 0), CVar_GetInt("gCCMagicPrimG", 200), CVar_GetInt("gCCMagicPrimB", 0), interfaceCtx->magicAlpha);
+            } else {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MAGIC_FILL_COLOR(0), R_MAGIC_FILL_COLOR(1), R_MAGIC_FILL_COLOR(2), interfaceCtx->magicAlpha);
+            }
 
             gDPLoadMultiBlock_4b(OVERLAY_DISP++, gMagicBarFillTex, 0, G_TX_RENDERTILE, G_IM_FMT_I, 16, 16, 0,
                                  G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
@@ -2768,7 +2799,13 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     // Also loads the Item Button Texture reused by other buttons afterwards
     gDPPipeSync(OVERLAY_DISP++);
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_B_BTN_COLOR(0), R_B_BTN_COLOR(1), R_B_BTN_COLOR(2), interfaceCtx->bAlpha);
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 150, 0, interfaceCtx->bAlpha);
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_B_BTN_COLOR(0), R_B_BTN_COLOR(1), R_B_BTN_COLOR(2), interfaceCtx->bAlpha);
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCBBtnPrimR", 90), CVar_GetInt("gCCBBtnPrimG", 90), CVar_GetInt("gCCBBtnPrimB", 255), interfaceCtx->bAlpha);
+    }
     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
 
     OVERLAY_DISP =
@@ -2777,24 +2814,39 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
 
     // C-Left Button Color & Texture
     gDPPipeSync(OVERLAY_DISP++);
-    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                    interfaceCtx->cLeftAlpha);
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cLeftAlpha);
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cLeftAlpha);
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), interfaceCtx->cLeftAlpha);
+    }
     gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(C_Left_BTN_Pos[0]) << 2, C_Left_BTN_Pos[1] << 2,
                         (OTRGetRectDimensionFromRightEdge(C_Left_BTN_Pos[0]) + R_ITEM_BTN_WIDTH(1)) << 2,
                         (C_Left_BTN_Pos[1] + R_ITEM_BTN_WIDTH(1)) << 2,
                         G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(1) << 1, R_ITEM_BTN_DD(1) << 1);
 
     // C-Down Button Color & Texture
-    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                    interfaceCtx->cDownAlpha);
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cDownAlpha);
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cDownAlpha);
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), interfaceCtx->cDownAlpha);
+    }
     gSPWideTextureRectangle(OVERLAY_DISP++,  OTRGetRectDimensionFromRightEdge(C_Down_BTN_Pos[0]) << 2, C_Down_BTN_Pos[1] << 2,
                         (OTRGetRectDimensionFromRightEdge(C_Down_BTN_Pos[0]) + R_ITEM_BTN_WIDTH(2)) << 2,
                         (C_Down_BTN_Pos[1] + R_ITEM_BTN_WIDTH(2)) << 2,
                         G_TX_RENDERTILE, 0, 0, R_ITEM_BTN_DD(2) << 1, R_ITEM_BTN_DD(2) << 1);
 
     // C-Right Button Color & Texture
-    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                    interfaceCtx->cRightAlpha);
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cRightAlpha);
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cRightAlpha);
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), interfaceCtx->cRightAlpha);
+    }
     gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(C_Right_BTN_Pos[0]) << 2, C_Right_BTN_Pos[1] << 2,
                         (OTRGetRectDimensionFromRightEdge(C_Right_BTN_Pos[0]) + R_ITEM_BTN_WIDTH(3)) << 2,
                         (C_Right_BTN_Pos[1] + R_ITEM_BTN_WIDTH(3)) << 2,
@@ -2804,10 +2856,12 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
         if ((globalCtx->pauseCtx.state != 0) || (globalCtx->pauseCtx.debugState != 0)) {
             // Start Button Texture, Color & Label
             gDPPipeSync(OVERLAY_DISP++);
-            if (CVar_GetS32("gN64Color", 0) !=0) {
-            	gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 0, 0, interfaceCtx->startAlpha);
-            } else {
-            	gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 120, 120, 120, interfaceCtx->startAlpha);
+            if (CVar_GetS32("gN64Colors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 0, 0, interfaceCtx->startAlpha);
+            } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 120, 120, 120, interfaceCtx->startAlpha);
+            } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCStartBtnPrimR", 120), CVar_GetInt("gCCStartBtnPrimG", 120), CVar_GetInt("gCCStartBtnPrimB", 120), interfaceCtx->startAlpha);
             }
             gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]) << 2, 68,
                                 (OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]) + 22) << 2, 156,
@@ -2821,7 +2875,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment + DO_ACTION_TEX_SIZE * 2, G_IM_FMT_IA,
                                    DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-            gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
+            gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
             dxdy = (1 << 10) / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
             width = DO_ACTION_TEX_WIDTH / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
             height = DO_ACTION_TEX_HEIGHT / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
@@ -2850,7 +2904,13 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
 
             const s16 rCUpBtnX  = OTRGetRectDimensionFromRightEdge(R_C_UP_BTN_X);
             const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X);
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
+            if (CVar_GetS32("gN64Colors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
+            } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
+            } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+              gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), temp);
+            }
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
             gSPWideTextureRectangle(OVERLAY_DISP++, rCUpBtnX << 2, R_C_UP_BTN_Y << 2, (rCUpBtnX + 16) << 2,
                                 (R_C_UP_BTN_Y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
@@ -2860,11 +2920,10 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                               PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
             gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
-            //gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, cUpLabelTextures[gSaveContext.language], G_IM_FMT_IA, 32, 8, 0,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                    G_TX_NOLOD, G_TX_NOLOD);
-            gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
+            gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
             gSPWideTextureRectangle(OVERLAY_DISP++, rCUPIconX << 2, R_C_UP_ICON_Y << 2, (rCUPIconX + 32) << 2,
                                 (R_C_UP_ICON_Y + 8) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
         }
@@ -3202,9 +3261,13 @@ void Interface_Draw(GlobalContext* globalCtx) {
             } else {
               rColor = &rupeeWalletColors[0];
             }
-
-            gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor[0], rColor[1], rColor[2], interfaceCtx->magicAlpha);
-            gDPSetEnvColor(OVERLAY_DISP++, 0, 80, 0, 255);
+            if (CVar_GetS32("gCustomColors", 0) != 0) {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCRupeePrimR", rColor[0]), CVar_GetInt("gCCRupeePrimG", rColor[1]), CVar_GetInt("gCCRupeePrimB", rColor[2]), interfaceCtx->magicAlpha);
+                gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255); //We reset this here so it match user color :)
+            } else {
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor[0], rColor[1], rColor[2], interfaceCtx->magicAlpha);
+                gDPSetEnvColor(OVERLAY_DISP++, 0, 80, 0, 255);
+            }
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26),
                                           206, 16, 16, 1 << 10, 1 << 10);
 
@@ -3414,8 +3477,13 @@ void Interface_Draw(GlobalContext* globalCtx) {
         //func_8008A8B8(globalCtx, R_A_BTN_Y, R_A_BTN_Y + 45, rABtnX, rABtnX + 45);
         gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BOTH);
         gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_A_BTN_COLOR(0), R_A_BTN_COLOR(1), R_A_BTN_COLOR(2),
-                        interfaceCtx->aAlpha);
+        if (CVar_GetS32("gN64Colors", 0) != 0) {
+          gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 90, 90, 255, interfaceCtx->aAlpha);
+        } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+          gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_A_BTN_COLOR(0), R_A_BTN_COLOR(1), R_A_BTN_COLOR(2), interfaceCtx->aAlpha);
+        } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+          gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 90), CVar_GetInt("gCCABtnPrimG", 90), CVar_GetInt("gCCABtnPrimB", 255), interfaceCtx->aAlpha);
+        }
 
         if (fullUi) {
             Interface_DrawActionButton(globalCtx, rABtnX, R_A_BTN_Y);

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -2270,8 +2270,7 @@ void EnOssan_DrawCursor(GlobalContext* globalCtx, EnOssan* this, f32 x, f32 y, f
     if (drawCursor != 0) {
         func_80094520(globalCtx->state.gfxCtx);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, this->cursorColorR, this->cursorColorG, this->cursorColorB, this->cursorColorA);
-        gDPLoadTextureBlock_4b(OVERLAY_DISP++, gSelectionCursorTex, G_IM_FMT_IA, 16, 16, 0, G_TX_MIRROR | G_TX_WRAP,
-                               G_TX_MIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+        gDPLoadTextureBlock_4b(OVERLAY_DISP++, gSelectionCursorTex, G_IM_FMT_IA, 16, 16, 0, G_TX_MIRROR | G_TX_WRAP, G_TX_MIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
         w = 16.0f * z;
         ulx = (x - w) * 4.0f;
         uly = (y - w) * 4.0f;

--- a/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/soh/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1887,9 +1887,19 @@ void EnOssan_UpdateCursorAnim(EnOssan* this) {
             this->cursorAnimState = 0;
         }
     }
-    this->cursorColorR = ColChanMix(0, 0.0f, t);
-    this->cursorColorG = ColChanMix(255, 80.0f, t);
-    this->cursorColorB = ColChanMix(80, 0.0f, t);
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      this->cursorColorR = ColChanMix(0, 0.0f, t);
+      this->cursorColorG = ColChanMix(80, 80.0f, t);
+      this->cursorColorB = ColChanMix(255, 0.0f, t);
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      this->cursorColorR = ColChanMix(0, 0.0f, t);
+      this->cursorColorG = ColChanMix(255, 80.0f, t);
+      this->cursorColorB = ColChanMix(80, 0.0f, t);
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      this->cursorColorR = ColChanMix(CVar_GetInt("gCCABtnPrimR", 90), ((CVar_GetInt("gCCABtnPrimR", 90)/255)*100), t);
+      this->cursorColorG = ColChanMix(CVar_GetInt("gCCABtnPrimG", 90), ((CVar_GetInt("gCCABtnPrimG", 90)/255)*100), t);
+      this->cursorColorB = ColChanMix(CVar_GetInt("gCCABtnPrimB", 90), ((CVar_GetInt("gCCABtnPrimB", 90)/255)*100), t);
+    }
     this->cursorColorA = ColChanMix(255, 0.0f, t);
     this->cursorAnimTween = t;
 }
@@ -2260,11 +2270,6 @@ void EnOssan_DrawCursor(GlobalContext* globalCtx, EnOssan* this, f32 x, f32 y, f
     if (drawCursor != 0) {
         func_80094520(globalCtx->state.gfxCtx);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, this->cursorColorR, this->cursorColorG, this->cursorColorB, this->cursorColorA);
-        if (CVar_GetS32("gN64Color", 0) !=0) {
-        	gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 42, 238, this->cursorColorA);
-        } else {
-        	gDPSetPrimColor(OVERLAY_DISP++, 0, 0, this->cursorColorR, this->cursorColorG, this->cursorColorB, this->cursorColorA);
-		}
         gDPLoadTextureBlock_4b(OVERLAY_DISP++, gSelectionCursorTex, G_IM_FMT_IA, 16, 16, 0, G_TX_MIRROR | G_TX_WRAP,
                                G_TX_MIRROR | G_TX_WRAP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
         w = 16.0f * z;

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -33,29 +33,29 @@ void Title_PrintBuildInfo(Gfx** gfxp) {
     GfxPrint_SetPos(&printer, 12, 20);
 
 #ifdef _MSC_VER
-    //GfxPrint_Printf(&printer, "MSVC SHIP");
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "MSVC SHIP");};
 #else
-    //GfxPrint_Printf(&printer, "GCC SHIP");
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "GCC SHIP");};
 #endif
 
     GfxPrint_SetPos(&printer, 5, 4);
-    //GfxPrint_Printf(&printer, "Game Version: %s", gameVersionStr);
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Game Version: %s", gameVersionStr);};
 
     GfxPrint_SetColor(&printer, 255, 255, 255, 255);
     GfxPrint_SetPos(&printer, 2, 22);
-    //GfxPrint_Printf(&printer, quote);
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, quote);};
     GfxPrint_SetPos(&printer, 1, 25);
-    //GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);};
     GfxPrint_SetPos(&printer, 3, 26);
-    //GfxPrint_Printf(&printer, "%s", gBuildTeam);
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "%s", gBuildTeam);};
     GfxPrint_SetPos(&printer, 3, 28);
-    //GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);
+    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);};
     g = GfxPrint_Close(&printer);
     GfxPrint_Destroy(&printer);
     *gfxp = g;
 }
 
-const char* quotes[11] = {
+const char* quotes[12] = {
     "My boy! This peace is what all true warriors strive for!",
     "Hmm. How can we help?",
     "Zelda! Duke Onkled is under attack by the evil forces of Ganon!",
@@ -66,12 +66,13 @@ const char* quotes[11] = {
     "I wonder what's for dinner.",
     "You've saved me!",
     "After you've scrubbed all the floors in Hyrule, then we can talk about mercy! Take him away!",
-    "Waaaahahahohohahahahahahaha"
+    "Waaaahahahohohahahahahahaha",
+    "Where is the 60 FPS mod? Enough! My ship sails in the morning."
 };
 
 char* SetQuote() {
     srand(time(NULL));
-    int randomQuote = rand() % 11;
+    int randomQuote = rand() % 12;
     return quotes[randomQuote];
 }
 

--- a/soh/src/overlays/gamestates/ovl_title/z_title.c
+++ b/soh/src/overlays/gamestates/ovl_title/z_title.c
@@ -33,23 +33,23 @@ void Title_PrintBuildInfo(Gfx** gfxp) {
     GfxPrint_SetPos(&printer, 12, 20);
 
 #ifdef _MSC_VER
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "MSVC SHIP");};
+    GfxPrint_Printf(&printer, "MSVC SHIP");
 #else
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "GCC SHIP");};
+    GfxPrint_Printf(&printer, "GCC SHIP");
 #endif
 
     GfxPrint_SetPos(&printer, 5, 4);
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Game Version: %s", gameVersionStr);};
+    GfxPrint_Printf(&printer, "Game Version: %s", gameVersionStr);
 
     GfxPrint_SetColor(&printer, 255, 255, 255, 255);
     GfxPrint_SetPos(&printer, 2, 22);
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, quote);};
+    GfxPrint_Printf(&printer, quote);
     GfxPrint_SetPos(&printer, 1, 25);
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);};
+    GfxPrint_Printf(&printer, "Build Date:%s", gBuildDate);
     GfxPrint_SetPos(&printer, 3, 26);
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "%s", gBuildTeam);};
+    GfxPrint_Printf(&printer, "%s", gBuildTeam);
     GfxPrint_SetPos(&printer, 3, 28);
-    if (CVar_GetS32("gBuildInfos", 0) != 1) {GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);};
+    GfxPrint_Printf(&printer, "Release Version: %s", gBuildVersion);
     g = GfxPrint_Close(&printer);
     GfxPrint_Destroy(&printer);
     *gfxp = g;
@@ -238,7 +238,9 @@ void Title_Main(GameState* thisx) {
         Gfx* gfx = POLY_OPA_DISP;
         s32 pad;
 
-        Title_PrintBuildInfo(&gfx);
+        if (CVar_GetS32("gBuildInfos", 0) != 1) {
+            Title_PrintBuildInfo(&gfx);
+        };
         POLY_OPA_DISP = gfx;
     }
 

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_collect.c
@@ -493,13 +493,21 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                     gDPPipeSync(POLY_KAL_DISP++);
 
                     if (D_8082A124[sp218] == 0) {
-                        if (CVar_GetS32("gN64Color", 0) !=0) {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, D_8082A150[sp218]);
-                        } else {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[sp218]);
+                        if (CVar_GetS32("gN64Colors", 0) != 0) { // A Button notes
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, D_8082A150[sp218]);
+                        } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[sp218]);
+                        } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 80), CVar_GetInt("gCCABtnPrimG", 255), CVar_GetInt("gCCABtnPrimB", 150), D_8082A150[sp218]);
                         }
                     } else {
+                      if (CVar_GetS32("gN64Colors", 0) != 0) { // C Buttons notes
                         gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[sp218]);
+                      } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[sp218]);
+                      } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), D_8082A150[sp218]);
+                      }
                     }
 
                     gDPSetEnvColor(POLY_KAL_DISP++, 10, 10, 10, 0);
@@ -527,13 +535,21 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
 
                 if (pauseCtx->unk_1E4 == 8) {
                     if (gOcarinaSongNotes[sp224].notesIdx[phi_s3] == 0) {
-                        if (CVar_GetS32("gN64Color", 0) !=0) {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, 200);
-                        } else {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, 200);
+                        if (CVar_GetS32("gN64Colors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, 200);
+                        } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, 200);
+                        } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 80), CVar_GetInt("gCCABtnPrimG", 255), CVar_GetInt("gCCABtnPrimB", 150), 200);
                         }
                     } else {
+                      if (CVar_GetS32("gN64Colors", 0) != 0) {
                         gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
+                      } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, 200);
+                      } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), 200);
+                      }
                     }
                 } else {
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 150, 150, 150, 150);
@@ -586,13 +602,21 @@ void KaleidoScope_DrawQuestStatus(GlobalContext* globalCtx, GraphicsContext* gfx
                     gDPPipeSync(POLY_KAL_DISP++);
 
                     if (D_8082A124[phi_s3] == 0) {
-                        if (CVar_GetS32("gN64Color", 0) !=0) {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, D_8082A150[phi_s3]);
-                        } else {
-                        	gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[phi_s3]);
+                        if (CVar_GetS32("gN64Colors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 150, 255, D_8082A150[phi_s3]);
+                        } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 80, 255, 150, D_8082A150[phi_s3]);
+                        } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                          gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 80), CVar_GetInt("gCCABtnPrimG", 255), CVar_GetInt("gCCABtnPrimB", 150), D_8082A150[phi_s3]);
                         }
                     } else {
+                      if (CVar_GetS32("gN64Colors", 0) != 0) {
                         gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[phi_s3]);
+                      } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 50, D_8082A150[phi_s3]);
+                      } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                        gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 255), CVar_GetInt("gCCCBtnPrimG", 160), CVar_GetInt("gCCCBtnPrimB", 0), D_8082A150[phi_s3]);
+                      }
                     }
 
                     gDPSetEnvColor(POLY_KAL_DISP++, 10, 10, 10, 0);

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -978,15 +978,19 @@ void KaleidoScope_DrawCursor(GlobalContext* globalCtx, u16 pageIndex) {
 
     temp = pauseCtx->unk_1E4;
 
-	if (CVar_GetS32("gN64Color", 0) !=0) {
-		sCursorColors[2][0] = 0;
-		sCursorColors[2][1] = 50;
-		sCursorColors[2][2] = 255;
-	} else {
-		sCursorColors[2][0] = 0;
-		sCursorColors[2][1] = 255;
-		sCursorColors[2][2] = 50;
-	};
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      sCursorColors[2][0] = 0;
+      sCursorColors[2][1] = 50;
+      sCursorColors[2][2] = 255;
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      sCursorColors[2][0] = 0;
+      sCursorColors[2][1] = 255;
+      sCursorColors[2][2] = 50;
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      sCursorColors[2][0] = CVar_GetInt("gCCABtnPrimR", 0);
+      sCursorColors[2][1] = CVar_GetInt("gCCABtnPrimG", 50);
+      sCursorColors[2][2] = CVar_GetInt("gCCABtnPrimB", 255);
+    }
 
 
     if ((((pauseCtx->unk_1E4 == 0) || (temp == 8)) && (pauseCtx->state == 6)) ||
@@ -1069,20 +1073,27 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
         { 0, 0, 0 },
         { 0, 255, 50 },
     };
-    if (CVar_GetS32("gN64Color", 0) !=0) {
-    	D_8082ACF4[8][0] = 0;
-    	D_8082ACF4[8][1] = 50;
-    	D_8082ACF4[8][2] = 255;
-    	D_8082ACF4[11][0] = 0;
-    	D_8082ACF4[11][1] = 50;
-    	D_8082ACF4[11][2] = 255;
-    } else {
-    	D_8082ACF4[8][0] = 0;
-    	D_8082ACF4[8][1] = 255;
-    	D_8082ACF4[8][2] = 50;
-    	D_8082ACF4[11][0] = 0;
-    	D_8082ACF4[11][1] = 255;
-    	D_8082ACF4[11][2] = 50;
+    if (CVar_GetS32("gN64Colors", 0) != 0) {
+      D_8082ACF4[8][0] = 0;
+      D_8082ACF4[8][1] = 50;
+      D_8082ACF4[8][2] = 255;
+      D_8082ACF4[11][0] = 0;
+      D_8082ACF4[11][1] = 50;
+      D_8082ACF4[11][2] = 255;
+    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+      D_8082ACF4[8][0] = 0;
+      D_8082ACF4[8][1] = 255;
+      D_8082ACF4[8][2] = 50;
+      D_8082ACF4[11][0] = 0;
+      D_8082ACF4[11][1] = 255;
+      D_8082ACF4[11][2] = 50;
+    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+      D_8082ACF4[8][0] = CVar_GetInt("gCCABtnPrimR", 0);
+      D_8082ACF4[8][1] = CVar_GetInt("gCCABtnPrimG", 50);
+      D_8082ACF4[8][2] = CVar_GetInt("gCCABtnPrimB", 255);
+      D_8082ACF4[11][0] = CVar_GetInt("gCCABtnPrimR", 0);
+      D_8082ACF4[11][1] = CVar_GetInt("gCCABtnPrimG", 50);
+      D_8082ACF4[11][2] = CVar_GetInt("gCCABtnPrimB", 255);
     }
     static s16 D_8082AD3C = 20;
     static s16 D_8082AD40 = 0;
@@ -1402,11 +1413,13 @@ void KaleidoScope_DrawPages(GlobalContext* globalCtx, GraphicsContext* gfxCtx) {
             POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, sSavePromptTexs[gSaveContext.language], 152, 16, 0);
 
             gDPSetCombineLERP(POLY_KAL_DISP++, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0, 1, 0, PRIMITIVE, 0, TEXEL0, 0, PRIMITIVE, 0);
-			if (CVar_GetS32("gN64Color", 0) !=0) {
-				gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 100, 100, 255, VREG(61));
-			} else {
-				gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 100, 255, 100, VREG(61)); //Save prompt cursor colour
-			}
+            if (CVar_GetS32("gN64Colors", 0) != 0) {//Save prompt cursor colour
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 100, 100, 255, VREG(61));
+            } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 100, 255, 100, VREG(61)); 
+            } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 0), CVar_GetInt("gCCABtnPrimG", 50), CVar_GetInt("gCCABtnPrimB", 255), VREG(61)); //Save prompt cursor colour
+            }
             if (pauseCtx->promptChoice == 0) {
                 gSPDisplayList(POLY_KAL_DISP++, gPromptCursorLeftDL);
             } else {
@@ -1694,17 +1707,16 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
             pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
             pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADE0[gSaveContext.language] << 5;
 
-          	// ===================== Custom button code start here ======================================
-
-        	if (CVar_GetS32("gN64Color", 0) !=0) {
-        		gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
-        	} else {
-        		gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]); //Set colour to gABtnSymbolTex
-        	}
-			gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
-			gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
-          	//POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, gABtnSymbolTex, 24, 16, 0);
             //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);
+            if (CVar_GetS32("gN64Colors", 0) != 0) {//A icon to decide in save prompt
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
+            } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
+            } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+              gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 0), CVar_GetInt("gCCABtnPrimG", 50), CVar_GetInt("gCCABtnPrimB", 255), 255);
+            }
+            gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+            gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
             //gDPPipeSync(POLY_KAL_DISP++);
 
             gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255); //A to decide in save prompt
@@ -1731,8 +1743,18 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                 pauseCtx->infoPanelVtx[21].v.ob[0] = pauseCtx->infoPanelVtx[23].v.ob[0] = pauseCtx->infoPanelVtx[20].v.ob[0] + D_8082ADD8[gSaveContext.language];
                 pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x600; //c button
                 pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADD8[gSaveContext.language] << 5;
-                gSPDisplayList(POLY_KAL_DISP++, gCButtonIconsDL);
-                gDPPipeSync(POLY_KAL_DISP++);
+                if (CVar_GetS32("gN64Colors", 0) != 0) {//To equip text C button icon
+                  gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), 255);
+                } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                  gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), 255);
+                } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                  gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCCBtnPrimR", 0), CVar_GetInt("gCCCBtnPrimG", 50), CVar_GetInt("gCCCBtnPrimB", 255), 255);
+                }
+                //gSPDisplayList(POLY_KAL_DISP++, gCButtonIconsDL); //Same reason for every A button, to be able to recolor them.
+                gDPLoadTextureBlock(POLY_KAL_DISP++, gCBtnSymbolsTex, G_IM_FMT_IA, G_IM_SIZ_8b, 48, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+                gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
+
+                //gDPPipeSync(POLY_KAL_DISP++);
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255); //To equip text next to C button icon
                 POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, D_8082AD54[gSaveContext.language], D_8082ADD8[gSaveContext.language], 16, 4);
             } else if ((pauseCtx->pageIndex == PAUSE_MAP) && sInDungeonScene) {
@@ -1750,14 +1772,17 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                     pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
                     pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADE8[gSaveContext.language] << 5;
 
-					if (CVar_GetS32("gN64Color", 0) !=0) {
-						gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
-					} else {
-						gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]); //Set colour to gABtnSymbolTex
-					}
-					gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
-					gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
-                  	//POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, gABtnSymbolTex, 24, 16, 0);
+                    if (CVar_GetS32("gN64Colors", 0) != 0) {//To play melody A button
+                      gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
+                    } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                      gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
+                    } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                      gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 0), CVar_GetInt("gCCABtnPrimG", 50), CVar_GetInt("gCCABtnPrimB", 255), 255);
+                    }
+                    //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);
+                    gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+                    gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
+                    gDPPipeSync(POLY_KAL_DISP++);
                     gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255); //To play melody text next to A button
                     POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, D_8082AD6C[gSaveContext.language], D_8082ADE8[gSaveContext.language], 16, 4);
                 }
@@ -1769,14 +1794,17 @@ void KaleidoScope_DrawInfoPanel(GlobalContext* globalCtx) {
                 pauseCtx->infoPanelVtx[17].v.tc[0] = pauseCtx->infoPanelVtx[19].v.tc[0] = 0x300;
                 pauseCtx->infoPanelVtx[21].v.tc[0] = pauseCtx->infoPanelVtx[23].v.tc[0] = D_8082ADD8[gSaveContext.language] << 5;
 
-		    	if (CVar_GetS32("gN64Color", 0) !=0) {
-		    		gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
-		    	} else {
-		    		gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]); //Set colour to gABtnSymbolTex
-		    	}
-                //POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, gABtnSymbolTex, 24, 16, 0);  //Re creation of the A button icon with our colour
-				gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
-				gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
+                if (CVar_GetS32("gN64Colors", 0) != 0) {//To play melody A button
+                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[1][0], gABtnTexColour[1][1], gABtnTexColour[1][2], gABtnTexColour[1][3]);
+                } else if (CVar_GetS32("gGameCubeColors", 0) != 0) {
+                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, gABtnTexColour[0][0], gABtnTexColour[0][1], gABtnTexColour[0][2], gABtnTexColour[0][3]);
+                } else if (CVar_GetS32("gCustomColors", 0) != 0) {
+                    gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, CVar_GetInt("gCCABtnPrimR", 0), CVar_GetInt("gCCABtnPrimG", 50), CVar_GetInt("gCCABtnPrimB", 255), 255);
+                }
+                //gSPDisplayList(POLY_KAL_DISP++, gAButtonIconDL);
+                gDPLoadTextureBlock(POLY_KAL_DISP++, gABtnSymbolTex, G_IM_FMT_IA, G_IM_SIZ_8b, 24, 16, 0, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD);
+                gSP1Quadrangle(POLY_KAL_DISP++, 0, 2, 3, 1, 0);
+                //gDPPipeSync(POLY_KAL_DISP++);
                 gDPSetPrimColor(POLY_KAL_DISP++, 0, 0, 255, 255, 255, 255); //To equip text next to A button
                 POLY_KAL_DISP = KaleidoScope_QuadTextureIA8(POLY_KAL_DISP, D_8082AD54[gSaveContext.language], D_8082ADD8[gSaveContext.language], 16, 4);
             }
@@ -3091,15 +3119,9 @@ void KaleidoScope_Update(GlobalContext* globalCtx){
                 if (gSaveContext.language == LANGUAGE_ENG) {
                     memcpy(pauseCtx->nameSegment + 0x400, ResourceMgr_LoadTexByName(mapNameTextures[36 + gSaveContext.worldMapArea]), 0xA00);
                 } else if (gSaveContext.language == LANGUAGE_GER) {
-                    DmaMgr_SendRequest1(pauseCtx->nameSegment + 0x400,
-                                        (uintptr_t)_map_name_staticSegmentRomStart +
-                                            (((void)0, gSaveContext.worldMapArea) * 0xA00) + 0x16C00,
-                                        0xA00, "../z_kaleido_scope_PAL.c", 3780);
+                    memcpy(pauseCtx->nameSegment + 0x400, ResourceMgr_LoadTexByName(mapNameTextures[59 + gSaveContext.worldMapArea]), 0xA00);
                 } else {
-                    DmaMgr_SendRequest1(pauseCtx->nameSegment + 0x400,
-                                        (uintptr_t)_map_name_staticSegmentRomStart +
-                                            (((void)0, gSaveContext.worldMapArea) * 0xA00) + 0x24800,
-                                        0xA00, "../z_kaleido_scope_PAL.c", 3784);
+                    memcpy(pauseCtx->nameSegment + 0x400, ResourceMgr_LoadTexByName(mapNameTextures[81 + gSaveContext.worldMapArea]), 0xA00);
                 }
             }
             // OTRTODO - player on pause


### PR DESCRIPTION
Added Graphics backend enhancements etc.  PR:#163 <- including fix for SDL in pause menu or crash.
Added Fix minimap update in dungeon #171 <- this use potential better fix than provided here, based on Rozelette comment. Quote : at the end of Map_InitData.
Added Changes fast text option to skip text, and makes text speed adjustable via a slider #173
Added Fix L/R buttons color in Kaleido menu #172 <- it remove the menu option but by default it is on, can be turned off in the .ini
Added MM Bunny Hood enhancement #181 <- can be turned on/off
Added Fix shift for G_LOADTILE #186
Added Fix OpenGL framebuffer index #195
Added [Mod]Color Scheme incl. N64 colors. #202 <- can be turned on/off
Added Fix languages Zone name on Kaleido #203
Added Fix Title card name for FRA and GER #204
Added Credits message order fix #205
Added Fixes text speed #207 <- this has an on first boot it will be at 0 just move it to 1 for original speed (or higher if you wish)
Added Option to hide/show Builds infos on startup while restoring it (Let have more respect to the Ship !)
Added instruction Dockerfile and "/libultraship/libultraship/SDLController.cpp" how to make it compatible with Ubuntu 20.04 and probably lower.
Modified language selection (now radioboxes)
Modified textures filtering for Navi C Button up & Start button to match A and B buttons.
Removed outdated N64 colors mod