### PR TITLE
Some fixes and feature check description :)

### DIFF
--- a/ZAPDTR/ZAPD/Globals.cpp
+++ b/ZAPDTR/ZAPD/Globals.cpp
@@ -20,6 +20,7 @@ Globals::Globals()
 	profile = false;
 	useLegacyZDList = false;
 	useExternalResources = true;
+	singleThreaded = true;
 	verbosity = VerbosityLevel::VERBOSITY_SILENT;
 	outputPath = Directory::GetCurrentDirectory();
 }

--- a/ZAPDTR/ZAPD/Main.cpp
+++ b/ZAPDTR/ZAPD/Main.cpp
@@ -31,17 +31,8 @@ const char gBuildHash[] = "";
 // linux todo: remove, those are because of soh <-> lus dependency problems
 float divisor_num = 0.0f;
 
-extern "C" void Audio_SetGameVolume(int player_id, float volume)
-{
-
-}
-
-
-extern "C" int ResourceMgr_OTRSigCheck(char* imgData)
-{
-
-}
-
+extern "C" void Audio_SetGameVolume(int player_id, float volume) {}
+extern "C" int ResourceMgr_OTRSigCheck(char* imgData){}
 
 bool Parse(const fs::path& xmlFilePath, const fs::path& basePath, const fs::path& outPath,
            ZFileMode fileMode, int workerID);

--- a/ZAPDTR/ZAPD/ZFile.cpp
+++ b/ZAPDTR/ZAPD/ZFile.cpp
@@ -619,7 +619,7 @@ bool ZFile::AddDeclarationChecks(uint32_t address, const std::string& varName)
 	assert(GETSEGNUM(address) == 0);
 	assert(varName != "");
 #ifdef DEVELOPMENT
-	if (address == 0x0000)
+	if (address == 0x000000)
 	{
 		[[maybe_unused]] int32_t bp = 0;
 	}
@@ -821,8 +821,31 @@ void ZFile::GenerateSourceHeaderFiles()
 	if (Globals::Instance->verbosity >= VerbosityLevel::VERBOSITY_INFO)
 		printf("Writing H file: %s\n", headerFilename.c_str());
 
-	if (Globals::Instance->fileMode != ZFileMode::ExtractDirectory)
+	if (Globals::Instance->fileMode != ZFileMode::ExtractDirectory) {
 		File::WriteAllText(headerFilename, formatter.GetOutput());
+	} else if (Globals::Instance->sourceOutputPath != "") {
+		std::string xmlPath = xmlFilePath.string();
+		xmlPath = StringHelper::Replace(xmlPath, "\\", "/");
+		auto pathList = StringHelper::Split(xmlPath, "/");
+		std::string outPath = "";
+
+		for (int i = 0; i < 3; i++)
+			outPath += pathList[i] + "/";
+
+		for (int i = 5; i < pathList.size(); i++) {
+			if (i == pathList.size() - 1) {
+				outPath += Path::GetFileNameWithoutExtension(pathList[i]) + "/";
+				outPath += outName.string() + ".h";
+			} else {
+				outPath += pathList[i];
+			}
+
+			if (i < pathList.size() - 1) {
+				outPath += "/";
+			}
+		}
+		File::WriteAllText(outPath, formatter.GetOutput());
+	}
 }
 
 std::string ZFile::GetHeaderInclude() const

--- a/libultraship/libultraship/Archive.cpp
+++ b/libultraship/libultraship/Archive.cpp
@@ -54,11 +54,16 @@ namespace Ship {
 	std::shared_ptr<File> Archive::LoadFile(const std::string& filePath, bool includeParent, std::shared_ptr<File> FileToLoad) {
 		HANDLE fileHandle = NULL;
 
+		if (FileToLoad == nullptr) {
+			FileToLoad = std::make_shared<File>();
+			FileToLoad->path = filePath;
+		}
+
 		if (!SFileOpenFileEx(mainMPQ, filePath.c_str(), 0, &fileHandle)) {
 			SPDLOG_ERROR("({}) Failed to open file {} from mpq archive {}", GetLastError(), filePath.c_str(), MainPath.c_str());
 			std::unique_lock<std::mutex> Lock(FileToLoad->FileLoadMutex);
 			FileToLoad->bHasLoadError = true;
-			return nullptr;
+			return FileToLoad;
 		}
 
 		DWORD dwFileSize = SFileGetFileSize(fileHandle, 0);
@@ -72,16 +77,11 @@ namespace Ship {
 			}
 			std::unique_lock<std::mutex> Lock(FileToLoad->FileLoadMutex);
 			FileToLoad->bHasLoadError = true;
-			return nullptr;
+			return FileToLoad;
 		}
 
 		if (!SFileCloseFile(fileHandle)) {
 			SPDLOG_ERROR("({}) Failed to close file {} from mpq archive {}", GetLastError(), filePath.c_str(), MainPath.c_str());
-		}
-
-		if (FileToLoad == nullptr) {
-			FileToLoad = std::make_shared<File>();
-			FileToLoad->path = filePath;
 		}
 
 		std::unique_lock<std::mutex> Lock(FileToLoad->FileLoadMutex);
@@ -96,6 +96,11 @@ namespace Ship {
 	std::shared_ptr<File> Archive::LoadPatchFile(const std::string& filePath, bool includeParent, std::shared_ptr<File> FileToLoad) {
 		HANDLE fileHandle = NULL;
 		HANDLE mpqHandle = NULL;
+
+		if (FileToLoad == nullptr) {
+			FileToLoad = std::make_shared<File>();
+			FileToLoad->path = filePath;
+		}
 
 		for(auto [path, handle] : mpqHandles) {
 			if (SFileOpenFileEx(mpqHandle, filePath.c_str(), 0, &fileHandle)) {
@@ -121,7 +126,7 @@ namespace Ship {
 			}
 			std::unique_lock<std::mutex> Lock(FileToLoad->FileLoadMutex);
 			FileToLoad->bHasLoadError = true;
-			return nullptr;
+			return FileToLoad;
 		}
 
 		if (!SFileCloseFile(fileHandle)) {

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -18,6 +18,10 @@ struct SoHConfigType {
     struct {
         bool show = false;
     } graphics;
+
+    struct {
+        bool uiedit = false;
+    } cosmetics;
 };
 
 enum SeqPlayers {

--- a/libultraship/libultraship/GameSettings.h
+++ b/libultraship/libultraship/GameSettings.h
@@ -6,6 +6,7 @@ struct SoHConfigType {
         bool soh = false;
         bool menu_bar = false;
         bool soh_sink = true;
+        bool mapselect = false;
     } debug;
 
     // Controller

--- a/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/gbi.h
+++ b/libultraship/libultraship/Lib/Fast3D/U64/PR/ultra64/gbi.h
@@ -4573,6 +4573,20 @@ _DW({                                   \
     _g2->words.w1 = (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16));	\
 }
 
+# define gsSPWideTextureRectangle(xl, yl, xh, yh, tile, s, t, dsdx, dtdy)   \
+{{									                                        \
+    (_SHIFTL(G_TEXRECT_WIDE, 24, 8) | _SHIFTL((xh), 0, 24)),			    \
+    _SHIFTL((yh), 0, 24),						                            \
+}},									                                        \
+{{									                                        \
+    (_SHIFTL((tile), 24, 3) | _SHIFTL((xl), 0, 24)),			            \
+    _SHIFTL((yl), 0, 24),						                            \
+}},									                                        \
+{{									                                        \
+    _SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16),				                    \
+    _SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16)			                \
+}}
+
  /* like gSPTextureRectangle but accepts negative position arguments */
 #define gSPScisTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
 _DW({                                                                            \

--- a/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
+++ b/libultraship/libultraship/Lib/Fast3D/gfx_opengl.cpp
@@ -611,6 +611,7 @@ static void gfx_opengl_init(void) {
     glGenBuffers(1, &opengl_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 
+    glEnable(GL_DEPTH_CLAMP);
     glDepthFunc(GL_LEQUAL);
     //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
@@ -776,8 +777,13 @@ static std::map<std::pair<float, float>, uint16_t> gfx_opengl_get_pixel_depth(in
         res.emplace(*coordinates.begin(), (depth_stencil_value >> 18) << 2);
     } else {
         if (pixel_depth_rb_size < coordinates.size()) {
+            // Resizing a renderbuffer seems broken with Intel's driver, so recreate one instead.
+            glBindFramebuffer(GL_FRAMEBUFFER, pixel_depth_fb);
+            glDeleteRenderbuffers(1, &pixel_depth_rb);
+            glGenRenderbuffers(1, &pixel_depth_rb);
             glBindRenderbuffer(GL_RENDERBUFFER, pixel_depth_rb);
             glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, coordinates.size(), 1);
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, pixel_depth_rb);
             glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
             pixel_depth_rb_size = coordinates.size();

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -317,9 +317,6 @@ namespace SohImGui {
     int ClampFloatToInt(float value, int min, int max){
         return fmin(fmax(value,min),max);
     }
-    float ClampIntToFloat(int value, float min, float max){
-        return fmin(fmax(value,min),max);
-    }
 
     void Init(WindowImpl window_impl) {
         impl = window_impl;
@@ -394,7 +391,7 @@ namespace SohImGui {
         }
     }
     
-    void EnhancementColorEdit3(std::string text, std::string cvarName, float ColorRGB[3]) {
+    void EnhancementColor3(std::string text, std::string cvarName, float ColorRGB[3]) {
         if (ImGui::ColorEdit3(text.c_str(), ColorRGB)) {
             CVar_SetS32((cvarName+"R").c_str(), ClampFloatToInt(ColorRGB[0]*255,0,255));
             CVar_SetS32((cvarName+"G").c_str(), ClampFloatToInt(ColorRGB[1]*255,0,255));
@@ -618,24 +615,24 @@ namespace SohImGui {
             if (ImGui::BeginMenu("Cosmetics")) {
                 if (ImGui::BeginMenu("Tunics")) {
                     EnhancementCheckbox("Custom colors on tunics", "gUseTunicsCol");
-                    EnhancementColorEdit3("Kokiri Tunic", "gTunic_Kokiri_", kokiri_col);
-                    EnhancementColorEdit3("Goron Tunic", "gTunic_Goron_", goron_col);
-                    EnhancementColorEdit3("Zora Tunic", "gTunic_Zora_", zora_col);
+                    EnhancementColor3("Kokiri Tunic", "gTunic_Kokiri_", kokiri_col);
+                    EnhancementColor3("Goron Tunic", "gTunic_Goron_", goron_col);
+                    EnhancementColor3("Zora Tunic", "gTunic_Zora_", zora_col);
                     ImGui::EndMenu();
                 }
                 if (ImGui::BeginMenu("Navi")) {
                     EnhancementCheckbox("Custom colors for Navi", "gUseNaviCol");
-                    EnhancementColorEdit3("Navi Idle Inner", "gNavi_Idle_Inner_", navi_idle_i_col);
-                    EnhancementColorEdit3("Navi Idle Outer", "gNavi_Idle_Outer_", navi_idle_o_col);
+                    EnhancementColor3("Navi Idle Inner", "gNavi_Idle_Inner_", navi_idle_i_col);
+                    EnhancementColor3("Navi Idle Outer", "gNavi_Idle_Outer_", navi_idle_o_col);
                     ImGui::Separator();
-                    EnhancementColorEdit3("Navi NPC Inner", "gNavi_NPC_Inner_", navi_npc_i_col);
-                    EnhancementColorEdit3("Navi NPC Outer", "gNavi_NPC_Outer_", navi_npc_o_col);
+                    EnhancementColor3("Navi NPC Inner", "gNavi_NPC_Inner_", navi_npc_i_col);
+                    EnhancementColor3("Navi NPC Outer", "gNavi_NPC_Outer_", navi_npc_o_col);
                     ImGui::Separator();
-                    EnhancementColorEdit3("Navi Enemy Inner", "gNavi_Enemy_Inner_", navi_enemy_i_col);
-                    EnhancementColorEdit3("Navi Enemy Outer", "gNavi_Enemy_Outer_", navi_enemy_o_col);
+                    EnhancementColor3("Navi Enemy Inner", "gNavi_Enemy_Inner_", navi_enemy_i_col);
+                    EnhancementColor3("Navi Enemy Outer", "gNavi_Enemy_Outer_", navi_enemy_o_col);
                     ImGui::Separator();
-                    EnhancementColorEdit3("Navi Prop Inner", "gNavi_Prop_Inner_", navi_prop_i_col);
-                    EnhancementColorEdit3("Navi Prop Outer", "gNavi_Prop_Outer_", navi_prop_o_col);
+                    EnhancementColor3("Navi Prop Inner", "gNavi_Prop_Inner_", navi_prop_i_col);
+                    EnhancementColor3("Navi Prop Outer", "gNavi_Prop_Outer_", navi_prop_o_col);
                     ImGui::EndMenu();
                 }
                 if (ImGui::BeginMenu("Interface")) {
@@ -644,26 +641,26 @@ namespace SohImGui {
                     EnhancementRadioButton("Custom Colors", "gHudColors", 2);
                     if (ImGui::BeginMenu("Edit HUD Colors")) {
                         if (ImGui::BeginMenu("Hearts")) {
-                            EnhancementColorEdit3("Hearts normals", "gCCHeartsPrim", hearts_colors);
-                            EnhancementColorEdit3("Hearts double def", "gDDCCHeartsPrim", hearts_dd_colors);
+                            EnhancementColor3("Hearts normals", "gCCHeartsPrim", hearts_colors);
+                            EnhancementColor3("Hearts double def", "gDDCCHeartsPrim", hearts_dd_colors);
                             ImGui::EndMenu();
                         }
                         if (ImGui::BeginMenu("Buttons")) {
-                            EnhancementColorEdit3("A Buttons", "gCCABtnPrim", a_btn_colors);
-                            EnhancementColorEdit3("B Buttons", "gCCBBtnPrim", b_btn_colors);
-                            EnhancementColorEdit3("C Buttons", "gCCCBtnPrim", c_btn_colors);
-                            EnhancementColorEdit3("Start Buttons", "gCCStartBtnPrim", start_btn_colors);
+                            EnhancementColor3("A Buttons", "gCCABtnPrim", a_btn_colors);
+                            EnhancementColor3("B Buttons", "gCCBBtnPrim", b_btn_colors);
+                            EnhancementColor3("C Buttons", "gCCCBtnPrim", c_btn_colors);
+                            EnhancementColor3("Start Buttons", "gCCStartBtnPrim", start_btn_colors);
                             ImGui::EndMenu();
                         }
                         if (ImGui::BeginMenu("Magic Bar")) {
-                            EnhancementColorEdit3("Magic bar borders", "gCCMagicBorderPrim", magic_border_colors);
-                            EnhancementColorEdit3("Magic bar main color", "gCCMagicPrim", magic_remaining_colors);
-                            EnhancementColorEdit3("Magic bar being used", "gCCMagicUsePrim", magic_use_colors);
+                            EnhancementColor3("Magic bar borders", "gCCMagicBorderPrim", magic_border_colors);
+                            EnhancementColor3("Magic bar main color", "gCCMagicPrim", magic_remaining_colors);
+                            EnhancementColor3("Magic bar being used", "gCCMagicUsePrim", magic_use_colors);
                             ImGui::EndMenu();
                         }
                         if (ImGui::BeginMenu("Misc")) {
-                            EnhancementColorEdit3("Minimap color", "gCCMinimapPrim", minimap_colors);
-                            EnhancementColorEdit3("Rupee icon color", "gCCRupeePrim", rupee_colors);
+                            EnhancementColor3("Minimap color", "gCCMinimapPrim", minimap_colors);
+                            EnhancementColor3("Rupee icon color", "gCCRupeePrim", rupee_colors);
                             ImGui::EndMenu();
                         }
                         ImGui::EndMenu();
@@ -674,17 +671,17 @@ namespace SohImGui {
             ImGui::EndMenu();
             }
             
-        if (Game::Settings.cosmetics.uiedit) {
-            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
-            ImGui::Begin("Interface modifier", nullptr, ImGuiWindowFlags_None);
-            EnhancementCheckbox("Use margins", "gHUDMargins");
-            EnhancementSliderInt("Top : %dx", "##UIMARGINT", "gHUDMargin_T", -20, 20, "");
-            EnhancementSliderInt("Left: %dx", "##UIMARGINL", "gHUDMargin_L", -25, 25, "");
-            EnhancementSliderInt("Right: %dx", "##UIMARGINR", "gHUDMargin_R", -25, 25, "");
-            EnhancementSliderInt("Bottom: %dx", "##UIMARGINB", "gHUDMargin_B", -20, 20, "");
-            ImGui::End();
-            ImGui::PopStyleColor();
-        }
+            if (Game::Settings.cosmetics.uiedit) {
+                ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
+                ImGui::Begin("Interface modifier", nullptr, ImGuiWindowFlags_None);
+                EnhancementCheckbox("Use margins", "gHUDMargins");
+                EnhancementSliderInt("Top : %dx", "##UIMARGINT", "gHUDMargin_T", -20, 20, "");
+                EnhancementSliderInt("Left: %dx", "##UIMARGINL", "gHUDMargin_L", -25, 25, "");
+                EnhancementSliderInt("Right: %dx", "##UIMARGINR", "gHUDMargin_R", -25, 25, "");
+                EnhancementSliderInt("Bottom: %dx", "##UIMARGINB", "gHUDMargin_B", -20, 20, "");
+                ImGui::End();
+                ImGui::PopStyleColor();
+            }
 
             if (CVar_GetS32("gLanguages", 0) == 0) {
                 SelectedLanguage = 0;
@@ -707,7 +704,7 @@ namespace SohImGui {
 
                 ImGui::Text("Debug");
                 ImGui::Separator();
-
+                EnhancementSliderInt("gDbgIntVal: %d", "##MapStage", "gDbgIntVal", 1, 99, "");
                 EnhancementCheckbox("Hide build infos", "gBuildInfos");
                 EnhancementCheckbox("Debug Mode (L + R + Z)", "gDebugEnabled");
                 EnhancementCheckbox("Debug Camera (DPad < + R)", "gDebugCamera");

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -17,7 +17,7 @@
 #include "Lib/stb/stb_image.h"
 #include "Lib/Fast3D/gfx_rendering_api.h"
 #include "Utils/StringHelper.h"
-#include "../../soh/soh/Enhancements/debugconsole.h"
+//#include "../../soh/soh/Enhancements/debugconsole.h"
 
 #ifdef ENABLE_OPENGL
 #include "Lib/ImGui/backends/imgui_impl_opengl3.h"
@@ -563,7 +563,8 @@ namespace SohImGui {
                 EnhancementCheckbox("Minimal UI", "gMinimalUI");
                 EnhancementCheckbox("MM Bunny Hood", "gMMBunnyHood");
                 EnhancementCheckbox("Visual Stone of Agony", "gVisualAgony");
-                EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
+
+                EnhancementCheckbox("Always show dungeon entrances", "gAlwaysShowDungeonMinimapIcon");
                 
                 ImGui::Text("Graphics");
                 ImGui::Separator();
@@ -573,6 +574,11 @@ namespace SohImGui {
                 EnhancementCheckbox("Enable 3D Dropped items", "gNewDrops");
                 EnhancementCheckbox("Dynamic Wallet Icon", "gDynamicWalletIcon");
 
+                if (ImGui::BeginMenu("Fixes")) {
+                    EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
+                    EnhancementCheckbox("Fix Dungeon entrances", "gFixDungeonMinimapIcon");
+                    ImGui::EndMenu();
+                }
                 ImGui::EndMenu();
             }
 
@@ -662,11 +668,24 @@ namespace SohImGui {
                         }
                         ImGui::EndMenu();
                     }
+                    HOOK(ImGui::MenuItem("Interface edit", nullptr, &Game::Settings.cosmetics.uiedit));
                     ImGui::EndMenu();
                 }
             ImGui::EndMenu();
             }
             
+        if (Game::Settings.cosmetics.uiedit) {
+            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 0, 0));
+            ImGui::Begin("Interface modifier", nullptr, ImGuiWindowFlags_None);
+            EnhancementCheckbox("Use margins", "gHUDMargins");
+            EnhancementSliderInt("Top : %dx", "##UIMARGINT", "gHUDMargin_T", -20, 20, "");
+            EnhancementSliderInt("Left: %dx", "##UIMARGINL", "gHUDMargin_L", -25, 25, "");
+            EnhancementSliderInt("Right: %dx", "##UIMARGINR", "gHUDMargin_R", -25, 25, "");
+            EnhancementSliderInt("Bottom: %dx", "##UIMARGINB", "gHUDMargin_B", -20, 20, "");
+            ImGui::End();
+            ImGui::PopStyleColor();
+        }
+
             if (CVar_GetS32("gLanguages", 0) == 0) {
                 SelectedLanguage = 0;
             } else if (CVar_GetS32("gLanguages", 0) == 1) {
@@ -974,7 +993,6 @@ namespace SohImGui {
     }
 
     void Render() {
-        console->Draw();
 
         ImGui::Render();
         ImGuiRenderDrawData(ImGui::GetDrawData());

--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -560,16 +560,22 @@ namespace SohImGui {
                 EnhancementCheckbox("Minimal UI", "gMinimalUI");
                 EnhancementCheckbox("MM Bunny Hood", "gMMBunnyHood");
                 EnhancementCheckbox("Visual Stone of Agony", "gVisualAgony");
-
                 EnhancementCheckbox("Always show dungeon entrances", "gAlwaysShowDungeonMinimapIcon");
-                
+                EnhancementCheckbox("Show clock", "gShowClock");
+                EnhancementCheckbox("Save Last Entrance", "gSaveEntrance");
+                //EnhancementSliderInt("Time speed: %dx (Req. time always flow)", "##TickMul", "gTickMultiplier", 0, 500, "");
+                //EnhancementCheckbox("Time always flow", "gAlwaysTick");
+
                 ImGui::Text("Graphics");
                 ImGui::Separator();
                 EnhancementCheckbox("N64 Mode", "gN64Mode");
                 EnhancementCheckbox("Animated Link in Pause Menu", "gPauseLiveLink");
                 EnhancementCheckbox("Disable LOD", "gDisableLOD");
+                EnhancementCheckbox("Disable Black Bars", "gDisableBlackBars");
                 EnhancementCheckbox("Enable 3D Dropped items", "gNewDrops");
                 EnhancementCheckbox("Dynamic Wallet Icon", "gDynamicWalletIcon");
+                
+                HOOK(ImGui::MenuItem("Anti-aliasing", nullptr, &Game::Settings.graphics.show));
 
                 if (ImGui::BeginMenu("Fixes")) {
                     EnhancementCheckbox("Fix L&R Pause menu", "gUniformLR");
@@ -597,11 +603,6 @@ namespace SohImGui {
                 EnhancementCheckbox("Unrestricted Items", "gNoRestrictItems");
                 EnhancementCheckbox("Freeze Time", "gFreezeTime");
 
-                ImGui::EndMenu();
-            }
-
-            if (ImGui::BeginMenu("Graphics")) {
-                HOOK(ImGui::MenuItem("Anti-aliasing", nullptr, &Game::Settings.graphics.show));
                 ImGui::EndMenu();
             }
 
@@ -704,7 +705,7 @@ namespace SohImGui {
 
                 ImGui::Text("Debug");
                 ImGui::Separator();
-                EnhancementSliderInt("gDbgIntVal: %d", "##MapStage", "gDbgIntVal", 1, 99, "");
+                EnhancementSliderInt("gDbgIntVal: %d", "##MapStage", "gDbgIntVal", 0, 100, "");
                 EnhancementCheckbox("Hide build infos", "gBuildInfos");
                 EnhancementCheckbox("Debug Mode (L + R + Z)", "gDebugEnabled");
                 EnhancementCheckbox("Debug Camera (DPad < + R)", "gDebugCamera");

--- a/libultraship/libultraship/SohImGuiImpl.h
+++ b/libultraship/libultraship/SohImGuiImpl.h
@@ -46,6 +46,12 @@ namespace SohImGui {
             void* event;
         } sdl;
     } EventImpl;
+
+    typedef struct {
+        std::string name;
+        int entranceIndex;
+    } SceneSelectList;
+
     extern Console* console;
     void SaveCVars();
     void Init(WindowImpl window_impl);

--- a/libultraship/libultraship/Window.cpp
+++ b/libultraship/libultraship/Window.cpp
@@ -279,8 +279,11 @@ namespace Ship {
         WmApi->set_keyboard_callbacks(Window::KeyDown, Window::KeyUp, Window::AllKeysUp);
     }
 
-    void Window::RunCommands(Gfx* Commands) {
+    void Window::StartFrame() {
         gfx_start_frame();
+    }
+
+    void Window::RunCommands(Gfx* Commands) {
         gfx_run(Commands);
         gfx_end_frame();
     }

--- a/libultraship/libultraship/Window.h
+++ b/libultraship/libultraship/Window.h
@@ -18,6 +18,7 @@ namespace Ship {
 			~Window();
 			void MainLoop(void (*MainFunction)(void));
 			void Init();
+			void StartFrame();
 			void RunCommands(Gfx* Commands);
 			void SetFrameDivisor(int divisor);
 			void GetPixelDepthPrepare(float x, float y);

--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -381,7 +381,7 @@ void Flags_UnsetTempClear(GlobalContext* globalCtx, s32 flag);
 s32 Flags_GetCollectible(GlobalContext* globalCtx, s32 flag);
 void Flags_SetCollectible(GlobalContext* globalCtx, s32 flag);
 void TitleCard_InitBossName(GlobalContext* globalCtx, TitleCardContext* titleCtx, void* texture, s16 x, s16 y, u8 width,
-                            u8 height);
+                            u8 height, s16 hastranslation);
 void TitleCard_InitPlaceName(GlobalContext* globalCtx, TitleCardContext* titleCtx, char* texture, s32 x, s32 y,
                              s32 width, s32 height, s32 delay);
 s32 func_8002D53C(GlobalContext* globalCtx, TitleCardContext* titleCtx);

--- a/soh/include/z64.h
+++ b/soh/include/z64.h
@@ -251,6 +251,8 @@ typedef struct {
     /* 0x0B */ u8       delayTimer; // how long the title card waits to appear
     /* 0x0C */ s16      alpha;
     /* 0x0E */ s16      intensity;
+    /* ---- */ s16      isBossCard; //To detect if that a Boss name title card.
+    /* ---- */ s16      hasTranslation; // to detect if the current title card has translation (used for bosses only)
 } TitleCardContext; // size = 0x10
 
 typedef struct {

--- a/soh/soh/Enhancements/bootcommands.c
+++ b/soh/soh/Enhancements/bootcommands.c
@@ -24,6 +24,7 @@ void BootCommands_Init()
 {
     CVar_RegisterS32("gDisableLOD", 0);
     CVar_RegisterS32("gDebugEnabled", 0);
+    CVar_RegisterS32("gDebugCamera", 0);
     CVar_RegisterS32("gPauseLiveLink", 0);
     CVar_RegisterS32("gMinimalUI", 0);
     CVar_RegisterS32("gReworkedControls", 0);

--- a/soh/soh/GbiWrap.cpp
+++ b/soh/soh/GbiWrap.cpp
@@ -5,6 +5,7 @@
 extern "C" {
 void InitOTR();
 void Graph_ProcessFrame(void (*run_one_game_iter)(void));
+void Graph_StartFrame();
 void Graph_ProcessGfxCommands(Gfx* commands);
 void OTRLogString(const char* src);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -235,6 +235,13 @@ extern "C" Gfx* ResourceMgr_LoadGfxByName(const char* path)
     return (Gfx*)&res->instructions[0];
 }
 
+extern "C" Gfx* ResourceMgr_PatchGfxByName(const char* path, int size) {
+    auto res = std::static_pointer_cast<Ship::DisplayList>(
+        OTRGlobals::Instance->context->GetResourceManager()->LoadResource(path));
+    res->instructions.resize(res->instructions.size() + size);
+    return (Gfx*)&res->instructions[0];
+}
+
 extern "C" char* ResourceMgr_LoadArrayByName(const char* path)
 {
     auto res = std::static_pointer_cast<Ship::Array>(OTRGlobals::Instance->context->GetResourceManager()->LoadResource(path));

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -92,6 +92,10 @@ extern "C" uint64_t GetPerfCounter() {
 }
 #endif
 
+extern "C" void Graph_StartFrame() {
+    OTRGlobals::Instance->context->GetWindow()->StartFrame();
+}
+
 // C->C++ Bridge
 extern "C" void Graph_ProcessFrame(void (*run_one_game_iter)(void)) {
     OTRGlobals::Instance->context->GetWindow()->MainLoop(run_one_game_iter);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -22,6 +22,7 @@ private:
 void InitOTR();
 void Graph_ProcessFrame(void (*run_one_game_iter)(void));
 void Graph_ProcessGfxCommands(Gfx* commands);
+void Graph_StartFrame();
 void OTRLogString(const char* src);
 void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(void*, char));
 void OTRSetFrameDivisor(int divisor);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -38,6 +38,7 @@ char* ResourceMgr_LoadPlayerAnimByName(const char* animPath);
 char* ResourceMgr_GetNameByCRC(uint64_t crc, char* alloc);
 Gfx* ResourceMgr_LoadGfxByCRC(uint64_t crc);
 Gfx* ResourceMgr_LoadGfxByName(const char* path);
+Gfx* ResourceMgr_PatchGfxByName(const char* path, int size);
 Vtx* ResourceMgr_LoadVtxByCRC(uint64_t crc);
 Vtx* ResourceMgr_LoadVtxByName(const char* path);
 CollisionHeader* ResourceMgr_LoadColByName(const char* path);

--- a/soh/src/code/db_camera.c
+++ b/soh/src/code/db_camera.c
@@ -539,6 +539,7 @@ void DbCamera_Init(DbCamera* dbCamera, Camera* cameraPtr) {
     dbCamera->unk_6C.x = 0;
     dbCamera->unk_6C.y = 0;
     dbCamera->unk_6C.z = 0;
+
 }
 
 void DbgCamera_Enable(DbCamera* dbCamera, Camera* cam) {

--- a/soh/src/code/game.c
+++ b/soh/src/code/game.c
@@ -422,14 +422,8 @@ void GameState_Update(GameState* gameState) {
         gSaveContext.dayTime = prevTime;
     }
 
-    //I added this check here to allow Player to switch languages on runtime
-    if (CVar_GetS32("gLanguages", 0) == 0) { 
-        gSaveContext.language = LANGUAGE_ENG;
-    } else if (CVar_GetS32("gLanguages", 0) == 1) {
-        gSaveContext.language = LANGUAGE_GER;
-    } else if (CVar_GetS32("gLanguages", 0) == 2) {
-        gSaveContext.language = LANGUAGE_FRA;
-    }
+    //since our CVar is same value and properly default to 0 there is not problems doing this in single line.
+    gSaveContext.language = CVar_GetS32("gLanguages", 0);
 
     gameState->frames++;
 }

--- a/soh/src/code/graph.c
+++ b/soh/src/code/graph.c
@@ -474,6 +474,8 @@ static void RunFrame()
             uint64_t ticksA, ticksB;
             ticksA = GetPerfCounter();
 
+            Graph_StartFrame();
+
             OTRSetFrameDivisor(R_UPDATE_RATE);
             //OTRSetFrameDivisor(0);
 

--- a/soh/src/code/shrink_window.c
+++ b/soh/src/code/shrink_window.c
@@ -6,6 +6,8 @@ s32 sShrinkWindowVal = 0;
 s32 sShrinkWindowCurrentVal = 0;
 
 void ShrinkWindow_SetVal(s32 value) {
+    if (CVar_GetS32("gDisableBlackBars", 0) != 0)
+        value = 0;
     if (HREG(80) == 0x13 && HREG(81) == 1) {
         osSyncPrintf("shrink_window_setval(%d)\n", value);
     }
@@ -17,6 +19,8 @@ u32 ShrinkWindow_GetVal(void) {
 }
 
 void ShrinkWindow_SetCurrentVal(s32 currentVal) {
+    if (CVar_GetS32("gDisableBlackBars", 0) != 0)
+        currentVal = 0;
     if (HREG(80) == 0x13 && HREG(81) == 1) {
         osSyncPrintf("shrink_window_setnowval(%d)\n", currentVal);
     }

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -1033,19 +1033,18 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         shiftBottomY = 0x1000;
 
         //if this card is bosses cards, has translation and that is not using English language.
-        if (titleCtx->isBossCard == 1 && titleCtx->hasTranslation == 1 && gSaveContext.language != LANGUAGE_ENG) {
+        if (titleCtx->isBossCard && titleCtx->hasTranslation && gSaveContext.language != LANGUAGE_ENG) {
+            textureLanguageOffset = (width * height * gSaveContext.language);
             if (gSaveContext.language == LANGUAGE_GER) {
-                textureLanguageOffset = (width * height * gSaveContext.language);
                 shiftTopY = 0x400;
                 shiftBottomY = 0x1400;
             } else if (gSaveContext.language == LANGUAGE_FRA) {
-                textureLanguageOffset = (width * height * gSaveContext.language);
                 shiftTopY = 0x800;
                 shiftBottomY = 0x1800;
             }
         }
 
-        gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + (uintptr_t)textureLanguageOffset + (uintptr_t)shiftTopY, G_IM_FMT_IA, G_IM_SIZ_8b,
+        gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + shiftTopY, G_IM_FMT_IA, G_IM_SIZ_8b,
                             width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                             G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
@@ -1057,7 +1056,7 @@ void TitleCard_Draw(GlobalContext* globalCtx, TitleCardContext* titleCtx) {
         // If texture is bigger than 0x1000, display the rest
         // for Boss Title card the the bottom part of it.
         if (height > 0) {
-            gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + (uintptr_t)textureLanguageOffset + (uintptr_t)shiftBottomY, G_IM_FMT_IA,
+            gDPLoadTextureBlock(WORLD_OVERLAY_DISP++, (uintptr_t)titleCtx->texture + textureLanguageOffset + shiftBottomY, G_IM_FMT_IA,
                                 G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
                                 G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 

--- a/soh/src/code/z_camera.c
+++ b/soh/src/code/z_camera.c
@@ -6787,6 +6787,11 @@ void Camera_Init(Camera* camera, View* view, CollisionContext* colCtx, GlobalCon
     s16 curUID;
     s16 j;
 
+    if (CVar_GetS32("gDebugCamera", 0) != 1) {
+        //This prevent some issue to rise if a person want to use ocarina outside dbg cam.
+        dbg_camera_pad_n = 1;
+    }
+
     memset(camera, 0, sizeof(*camera));
     if (sInitRegs) {
         for (i = 0; i < sOREGInitCnt; i++) {

--- a/soh/src/code/z_fbdemo_circle.c
+++ b/soh/src/code/z_fbdemo_circle.c
@@ -147,7 +147,7 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
 
     modelView = this->modelView[this->frame];
 
-    this->color.rgba = 0xFFFFFFFF;
+    //this->color.rgba = 0xFFFFFFFF;
 
     this->frame ^= 1;
     gDPPipeSync(gfx++);

--- a/soh/src/code/z_kankyo.c
+++ b/soh/src/code/z_kankyo.c
@@ -2264,6 +2264,29 @@ Color_RGB8 sSandstormEnvColors[] = {
     { 50, 40, 0 },
 };
 
+Gfx* gFieldSandstormDL_Custom = NULL;
+
+void Environment_PatchSandstorm(GlobalContext* globalCtx) {
+    if (gFieldSandstormDL_Custom) return;
+
+    gFieldSandstormDL_Custom = ResourceMgr_PatchGfxByName(gFieldSandstormDL, -3);
+
+    const Gfx gFSPatchDL[2] = { gsSPEndDisplayList() };
+    bool patched = false;
+    Gfx* cmd = gFieldSandstormDL_Custom;
+    int id = 0;
+
+    while (!patched) {
+        const uint32_t opcode = cmd->words.w0 >> 24;
+        if (opcode == G_TEXRECT) {
+            gFieldSandstormDL_Custom[id] = gFSPatchDL[0];
+            patched = true;
+        }
+        ++cmd;
+        id++;
+    }
+}
+
 void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {
     s32 primA1;
     s32 envA1;
@@ -2276,6 +2299,8 @@ void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {
     u16 sp96;
     u16 sp94;
     u16 sp92;
+
+    Environment_PatchSandstorm(globalCtx);
 
     switch (sandstormState) {
         case 3:
@@ -2383,8 +2408,11 @@ void Environment_DrawSandstorm(GlobalContext* globalCtx, u8 sandstormState) {
                Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, (u32)sp96 % 0x1000, 0, 0x200, 0x20, 1, (u32)sp94 % 0x1000,
                                 0xFFF - ((u32)sp92 % 0x1000), 0x100, 0x40));
     gDPSetTextureLUT(POLY_XLU_DISP++, G_TT_NONE);
-    gSPDisplayList(POLY_XLU_DISP++, gFieldSandstormDL);
-
+    //gSPDisplayList(POLY_XLU_DISP++, gFieldSandstormDL);
+    gSPDisplayList(POLY_XLU_DISP++, gFieldSandstormDL_Custom);
+    gSPWideTextureRectangle(POLY_XLU_DISP++, OTRGetRectDimensionFromLeftEdge(0) << 2, 0,
+                            OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH) << 2, 0x03C0, G_TX_RENDERTILE, 0, 0, 0x008C,
+                            -0x008C);
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_kankyo.c", 4068);
 
     D_8015FDB0 += (s32)sp98;

--- a/soh/src/code/z_lifemeter.c
+++ b/soh/src/code/z_lifemeter.c
@@ -1,6 +1,11 @@
 #include "global.h"
 #include "textures/parameter_static/parameter_static.h"
 
+s16 Top_LM_Margin = 0;
+s16 Left_LM_Margin = 0;
+s16 Right_LM_Margin = 0;
+s16 Bottom_LM_Margin = 0;
+
 static s16 sHeartsPrimColors[3][3] = {
     { HEARTS_PRIM_R, HEARTS_PRIM_G, HEARTS_PRIM_B },
     { HEARTS_BURN_PRIM_R, HEARTS_BURN_PRIM_G, HEARTS_BURN_PRIM_B },    // unused
@@ -165,6 +170,18 @@ void HealthMeter_Update(GlobalContext* globalCtx) {
     s16 rFactor;
     s16 gFactor;
     s16 bFactor;
+
+    if (CVar_GetS32("gHUDMargins", 0) != 0) {
+        Top_LM_Margin = CVar_GetS32("gHUDMargin_T", 0);
+        Left_LM_Margin = CVar_GetS32("gHUDMargin_L", 0);
+        Right_LM_Margin = CVar_GetS32("gHUDMargin_R", 0);
+        Bottom_LM_Margin = CVar_GetS32("gHUDMargin_B", 0);
+    } else {
+        Top_LM_Margin = 0;
+        Left_LM_Margin = 0;
+        Right_LM_Margin = 0;
+        Bottom_LM_Margin = 0;
+    }
 
     if (interfaceCtx) {}
 
@@ -357,8 +374,8 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
     }
 
     curColorSet = -1;
-    offsetY = 0.0f;
-    offsetX = OTRGetDimensionFromLeftEdge(0.0f);
+    offsetY = 0.0f+(Top_LM_Margin*-1);
+    offsetX = OTRGetDimensionFromLeftEdge(0.0f)+(Left_LM_Margin*-1);
 
     for (i = 0; i < totalHeartCount; i++) {
         if ((ddHeartCountMinusOne < 0) || (i > ddHeartCountMinusOne)) {
@@ -518,7 +535,7 @@ void HealthMeter_Draw(GlobalContext* globalCtx) {
         offsetX += 10.0f;
         if (i == 9) {
             offsetY += 10.0f;
-            offsetX = OTRGetDimensionFromLeftEdge(0.0f);
+            offsetX = OTRGetDimensionFromLeftEdge(0.0f)+(Left_LM_Margin*-1);
         }
     }
 

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -725,7 +725,7 @@ void Minimap_Draw(GlobalContext* globalCtx) {
 
                     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
                     if (CVar_GetS32("gHudColors", 1) == 2) {//Overworld minimap
-                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMinimapPrimR", 255), CVar_GetS32("gCCMinimapPrimG", 255), CVar_GetS32("gCCMinimapPrimB", 255), interfaceCtx->magicAlpha);
+                        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCMinimapPrimR", 255), CVar_GetS32("gCCMinimapPrimG", 255), CVar_GetS32("gCCMinimapPrimB", 255), interfaceCtx->minimapAlpha);
                     } else {
                         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
                     }
@@ -742,7 +742,6 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                            (oWMiniMapX + gMapData->owMinimapWidth[mapIndex]) << 2,
                                            (oWMiniMapY + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, 0,
                                             0, 1 << 10, 1 << 10);
-
                     if (CVar_GetS32("gHudColors", 1) != 2) {//This need to be added else it will color dungeon entrance icon too. (it re-init prim color to default color)
                         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
                     }

--- a/soh/src/code/z_map_exp.c
+++ b/soh/src/code/z_map_exp.c
@@ -13,6 +13,11 @@ s16 sPlayerInitialPosZ = 0;
 s16 sPlayerInitialDirection = 0;
 s16 sEntranceIconMapIndex = 0;
 
+s16 Top_MM_Margin = 0;
+s16 Left_MM_Margin = 0;
+s16 Right_MM_Margin = 0;
+s16 Bottom_MM_Margin = 0;
+
 void Map_SavePlayerInitialInfo(GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
@@ -603,11 +608,11 @@ void Minimap_DrawCompassIcons(GlobalContext* globalCtx) {
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
         gDPSetCombineMode(OVERLAY_DISP++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
-        tempX = player->actor.world.pos.x;
-        tempZ = player->actor.world.pos.z;
+        tempX = player->actor.world.pos.x+Right_MM_Margin;
+        tempZ = player->actor.world.pos.z+Bottom_MM_Margin;
         tempX /= R_COMPASS_SCALE_X;
         tempZ /= R_COMPASS_SCALE_Y;
-        Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X + tempX) / 10.0f), (R_COMPASS_OFFSET_Y - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
+        Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(Right_MM_Margin*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Bottom_MM_Margin*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
         Matrix_Scale(0.4f, 0.4f, 0.4f, MTXMODE_APPLY);
         Matrix_RotateX(-1.6f, MTXMODE_APPLY);
         tempX = (0x7FFF - player->actor.shape.rot.y) / 0x400;
@@ -617,11 +622,11 @@ void Minimap_DrawCompassIcons(GlobalContext* globalCtx) {
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 255, 0, 255);
         gSPDisplayList(OVERLAY_DISP++, gCompassArrowDL);
 
-        tempX = sPlayerInitialPosX;
-        tempZ = sPlayerInitialPosZ;
+        tempX = sPlayerInitialPosX+Right_MM_Margin;
+        tempZ = sPlayerInitialPosZ+Bottom_MM_Margin;
         tempX /= R_COMPASS_SCALE_X;
         tempZ /= R_COMPASS_SCALE_Y;
-        Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X + tempX) / 10.0f), (R_COMPASS_OFFSET_Y - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
+        Matrix_Translate(OTRGetDimensionFromRightEdge((R_COMPASS_OFFSET_X+(Right_MM_Margin*10) + tempX) / 10.0f), (R_COMPASS_OFFSET_Y+((Bottom_MM_Margin*10)*-1) - tempZ) / 10.0f, 0.0f, MTXMODE_NEW);
         Matrix_Scale(VREG(9) / 100.0f, VREG(9) / 100.0f, VREG(9) / 100.0f, MTXMODE_APPLY);
         Matrix_RotateX(VREG(52) / 10.0f, MTXMODE_APPLY);
         Matrix_RotateY(sPlayerInitialDirection / 10.0f, MTXMODE_APPLY);
@@ -668,10 +673,11 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                                G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-                        const s16 dgnMiniMapX = OTRGetRectDimensionFromRightEdge(R_DGN_MINIMAP_X);
+                        const s16 dgnMiniMapX = OTRGetRectDimensionFromRightEdge(R_DGN_MINIMAP_X + Right_MM_Margin);
+                        const s16 dgnMiniMapY = R_DGN_MINIMAP_Y + Bottom_MM_Margin;
 
-                        gSPWideTextureRectangle(OVERLAY_DISP++, dgnMiniMapX << 2, R_DGN_MINIMAP_Y << 2,
-                                            (dgnMiniMapX + 96) << 2, (R_DGN_MINIMAP_Y + 85) << 2, G_TX_RENDERTILE,
+                        gSPWideTextureRectangle(OVERLAY_DISP++, dgnMiniMapX << 2, dgnMiniMapY << 2,
+                                            (dgnMiniMapX + 96) << 2, (dgnMiniMapY + 85) << 2, G_TX_RENDERTILE,
                                             0, 0, 1 << 10, 1 << 10);
                     }
 
@@ -729,35 +735,42 @@ void Minimap_Draw(GlobalContext* globalCtx) {
                                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                            G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-                    const s16 oWMiniMapX = OTRGetRectDimensionFromRightEdge(R_OW_MINIMAP_X);
+                    const s16 oWMiniMapX = OTRGetRectDimensionFromRightEdge(R_OW_MINIMAP_X + Right_MM_Margin);
+                    const s16 oWMiniMapY = R_OW_MINIMAP_Y + Bottom_MM_Margin;
 
-                    gSPWideTextureRectangle(OVERLAY_DISP++, oWMiniMapX << 2, R_OW_MINIMAP_Y << 2,
+                    gSPWideTextureRectangle(OVERLAY_DISP++, oWMiniMapX << 2, oWMiniMapY << 2,
                                            (oWMiniMapX + gMapData->owMinimapWidth[mapIndex]) << 2,
-                                           (R_OW_MINIMAP_Y + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, 0,
+                                           (oWMiniMapY + gMapData->owMinimapHeight[mapIndex]) << 2, G_TX_RENDERTILE, 0,
                                             0, 1 << 10, 1 << 10);
 
                     if (CVar_GetS32("gHudColors", 1) != 2) {//This need to be added else it will color dungeon entrance icon too. (it re-init prim color to default color)
                         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_MINIMAP_COLOR(0), R_MINIMAP_COLOR(1), R_MINIMAP_COLOR(2), interfaceCtx->minimapAlpha);
                     }
 
-                    if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) &&
-                         (globalCtx->sceneNum != SCENE_SPOT08)) ||
-                        (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
-                        if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) ||
-                            ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) &&
-                             (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]))) {
-
-                            gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
-                                                8, 8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
-                                                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-
-                            gSPWideTextureRectangle(OVERLAY_DISP++,
-                                                OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex]) << 2,
-                                                gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2,
-                                                OTRGetRectDimensionFromLeftEdge(gMapData->owEntranceIconPosX[sEntranceIconMapIndex] + 8) << 2,
-                                                (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] + 8) << 2,
-                                                G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                    if (((globalCtx->sceneNum != SCENE_SPOT01) && (globalCtx->sceneNum != SCENE_SPOT04) && (globalCtx->sceneNum != SCENE_SPOT08)) || (LINK_AGE_IN_YEARS != YEARS_ADULT)) {
+                        s16 IconSize = 8;
+                        s16 PosX = gMapData->owEntranceIconPosX[sEntranceIconMapIndex]+Right_MM_Margin;
+                        s16 PosY = gMapData->owEntranceIconPosY[sEntranceIconMapIndex]+Bottom_MM_Margin;
+                        if (CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){ //gFixDungeonMinimapIcon fix both Y position of visible icon and hide these non needed.
+                            PosY = PosY+1024; //No idea why and how Original value work but this does actually fix them all.
                         }
+                        s16 TopLeftX = OTRGetRectDimensionFromRightEdge(PosX) << 2;
+                        s16 TopLeftY = PosY << 2;
+                        s16 TopLeftW = OTRGetRectDimensionFromRightEdge(PosX + IconSize) << 2;
+                        s16 TopLeftH = (PosY + IconSize) << 2;
+                        if ((gMapData->owEntranceFlag[sEntranceIconMapIndex] == 0xFFFF) || ((gMapData->owEntranceFlag[sEntranceIconMapIndex] != 0xFFFF) && (gSaveContext.infTable[26] & gBitFlags[gMapData->owEntranceFlag[mapIndex]]))) {
+                            if (gMapData->owEntranceIconPosY[sEntranceIconMapIndex] << 2 != 0 && CVar_GetS32("gFixDungeonMinimapIcon", 1) != 0){
+                                gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
+                                                    IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                    G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                                gSPWideTextureRectangle(OVERLAY_DISP++, TopLeftX, TopLeftY, TopLeftW, TopLeftH, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                            }
+                        } else if (CVar_GetS32("gAlwaysShowDungeonMinimapIcon", 0) != 0){ //Ability to show entrance Before beating the dungeon itself
+                            gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b,
+                                                IconSize, IconSize, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP,
+                                                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                            gSPWideTextureRectangle(OVERLAY_DISP++, TopLeftX, TopLeftY, TopLeftW, TopLeftH, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+                        } 
                     }
 					if ((globalCtx->sceneNum == SCENE_SPOT08) && (gSaveContext.infTable[26] & gBitFlags[9])) {
                         gDPLoadTextureBlock(OVERLAY_DISP++, gMapDungeonEntranceIconTex, G_IM_FMT_RGBA, G_IM_SIZ_16b, 8,
@@ -801,6 +814,18 @@ void Map_Update(GlobalContext* globalCtx) {
     InterfaceContext* interfaceCtx = &globalCtx->interfaceCtx;
     s16 floor;
     s16 i;
+
+    if (CVar_GetS32("gHUDMargins", 0) != 0) {
+        Top_MM_Margin = CVar_GetS32("gHUDMargin_T", 0);
+        Left_MM_Margin = CVar_GetS32("gHUDMargin_L", 0);
+        Right_MM_Margin = CVar_GetS32("gHUDMargin_R", 0);
+        Bottom_MM_Margin = CVar_GetS32("gHUDMargin_B", 0);
+    } else {
+        Top_MM_Margin = 0;
+        Left_MM_Margin = 0;
+        Right_MM_Margin = 0;
+        Bottom_MM_Margin = 0;
+    }
 
     if ((globalCtx->pauseCtx.state == 0) && (globalCtx->pauseCtx.debugState == 0)) {
         switch (globalCtx->sceneNum) {

--- a/soh/src/code/z_map_mark.c
+++ b/soh/src/code/z_map_mark.c
@@ -108,6 +108,23 @@ void MapMark_DrawForDungeon(GlobalContext* globalCtx) {
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->minimapAlpha);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, interfaceCtx->minimapAlpha);
 
+        s16 Top_MC_Margin = 0;
+        s16 Left_MC_Margin = 0;
+        s16 Right_MC_Margin = 0;
+        s16 Bottom_MC_Margin = 0;
+
+        if (CVar_GetS32("gHUDMargins", 0) != 0) {
+            Top_MC_Margin = CVar_GetS32("gHUDMargin_T", 0);
+            Left_MC_Margin = CVar_GetS32("gHUDMargin_L", 0);
+            Right_MC_Margin = CVar_GetS32("gHUDMargin_R", 0);
+            Bottom_MC_Margin = CVar_GetS32("gHUDMargin_B", 0);
+        } else {
+            Top_MC_Margin = 0;
+            Left_MC_Margin = 0;
+            Right_MC_Margin = 0;
+            Bottom_MC_Margin = 0;
+        }
+
         markPoint = &mapMarkIconData->points[0];
         for (i = 0; i < mapMarkIconData->count; i++) {
             if ((mapMarkIconData->markType != MAP_MARK_CHEST) || !Flags_GetTreasure(globalCtx, markPoint->chestFlag)) {
@@ -118,8 +135,8 @@ void MapMark_DrawForDungeon(GlobalContext* globalCtx) {
                                     markInfo->textureWidth, markInfo->textureHeight, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                     G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-                rectLeft = (GREG(94) + OTRGetRectDimensionFromRightEdge(markPoint->x) + 204) << 2;
-                rectTop = (GREG(95) + markPoint->y + 140) << 2;
+                rectLeft = (GREG(94) + OTRGetRectDimensionFromRightEdge(markPoint->x+Right_MC_Margin) + 204) << 2;
+                rectTop = (GREG(95) + markPoint->y + Bottom_MC_Margin + 140) << 2;
                 gSPTextureRectangle(OVERLAY_DISP++, rectLeft, rectTop, markInfo->rectWidth + rectLeft,
                                     rectTop + markInfo->rectHeight, G_TX_RENDERTILE, 0, 0, markInfo->dsdx,
                                     markInfo->dtdy);

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -15,6 +15,11 @@
 #define DO_ACTION_TEX_HEIGHT 16
 #define DO_ACTION_TEX_SIZE ((DO_ACTION_TEX_WIDTH * DO_ACTION_TEX_HEIGHT) / 2) // (sizeof(gCheckDoActionENGTex))
 
+s16 Top_HUD_Margin = 0;
+s16 Left_HUD_Margin = 0;
+s16 Right_HUD_Margin = 0;
+s16 Bottom_HUD_Margin = 0;
+
 typedef struct {
     /* 0x00 */ u8 scene;
     /* 0x01 */ u8 flags1;
@@ -2640,9 +2645,9 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
 
     if (gSaveContext.magicLevel != 0) {
         if (gSaveContext.healthCapacity > 0xA0) {
-            magicBarY = R_MAGIC_BAR_LARGE_Y;
+            magicBarY = R_MAGIC_BAR_LARGE_Y + (Top_HUD_Margin*-1);
         } else {
-            magicBarY = R_MAGIC_BAR_SMALL_Y;
+            magicBarY = R_MAGIC_BAR_SMALL_Y + (Top_HUD_Margin*-1);
         }
 
         func_80094520(globalCtx->state.gfxCtx);
@@ -2655,16 +2660,16 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
         }
 
         OVERLAY_DISP =
-            Gfx_TextureIA8(OVERLAY_DISP, gMagicBarEndTex, 8, 16, OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X),
+            Gfx_TextureIA8(OVERLAY_DISP, gMagicBarEndTex, 8, 16, OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X + (Left_HUD_Margin*-1)),
                                       magicBarY, 8, 16, 1 << 10, 1 << 10);
 
-        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gMagicBarMidTex, 24, 16, OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X) + 8, magicBarY,
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gMagicBarMidTex, 24, 16, OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X + (Left_HUD_Margin*-1)) + 8, magicBarY,
                                       gSaveContext.unk_13F4, 16, 1 << 10, 1 << 10);
 
         gDPLoadTextureBlock(OVERLAY_DISP++, gMagicBarEndTex, G_IM_FMT_IA, G_IM_SIZ_8b, 8, 16, 0,
                             G_TX_MIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, 3, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-        const s16 rMagicBarX = OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X);
+        const s16 rMagicBarX = OTRGetRectDimensionFromLeftEdge(R_MAGIC_BAR_X + (Left_HUD_Margin*-1));
 
         gSPWideTextureRectangle(OVERLAY_DISP++, ((rMagicBarX + gSaveContext.unk_13F4) + 8) << 2, magicBarY << 2,
                             ((rMagicBarX + gSaveContext.unk_13F4) + 16) << 2, (magicBarY + 16) << 2, G_TX_RENDERTILE,
@@ -2675,7 +2680,7 @@ void Interface_DrawMagicBar(GlobalContext* globalCtx) {
                           ENVIRONMENT, TEXEL0, ENVIRONMENT, 0, 0, 0, PRIMITIVE);
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
 
-        const s16 rMagicFillX = OTRGetRectDimensionFromLeftEdge(R_MAGIC_FILL_X);
+        const s16 rMagicFillX = OTRGetRectDimensionFromLeftEdge(R_MAGIC_FILL_X + (Left_HUD_Margin*-1));
 
         if (gSaveContext.unk_13F0 == 4) {
             // Yellow part of the bar indicating the amount of magic to be subtracted
@@ -2788,10 +2793,10 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     s16 width;
     s16 height;
 
-    s16 C_Left_BTN_Pos[]  = { C_LEFT_BUTTON_X, C_LEFT_BUTTON_Y }; //(X,Y)
-    s16 C_Right_BTN_Pos[] = { C_RIGHT_BUTTON_X, C_RIGHT_BUTTON_Y };
-    s16 C_Up_BTN_Pos[]    = { C_UP_BUTTON_X, C_UP_BUTTON_Y };
-    s16 C_Down_BTN_Pos[]  = { C_DOWN_BUTTON_X, C_DOWN_BUTTON_Y };
+    s16 C_Left_BTN_Pos[]  = { C_LEFT_BUTTON_X+Right_HUD_Margin, C_LEFT_BUTTON_Y+(Top_HUD_Margin*-1) }; //(X,Y)
+    s16 C_Right_BTN_Pos[] = { C_RIGHT_BUTTON_X+Right_HUD_Margin, C_RIGHT_BUTTON_Y+(Top_HUD_Margin*-1) };
+    s16 C_Up_BTN_Pos[]    = { C_UP_BUTTON_X+Right_HUD_Margin, C_UP_BUTTON_Y+(Top_HUD_Margin*-1) };
+    s16 C_Down_BTN_Pos[]  = { C_DOWN_BUTTON_X+Right_HUD_Margin, C_DOWN_BUTTON_Y+(Top_HUD_Margin*-1) };
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_parameter.c", 2900);
 
@@ -2809,7 +2814,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
 
     OVERLAY_DISP =
-        Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(0)), R_ITEM_BTN_Y(0),
+        Gfx_TextureIA8(OVERLAY_DISP, gButtonBackgroundTex, 32, 32, OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(0)+Right_HUD_Margin), R_ITEM_BTN_Y(0)+(Top_HUD_Margin*-1),
                        R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_WIDTH(0), R_ITEM_BTN_DD(0) << 1, R_ITEM_BTN_DD(0) << 1);
 
     // C-Left Button Color & Texture
@@ -2863,8 +2868,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             } else if (CVar_GetS32("gHudColors", 1) == 2) {
               gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCStartBtnPrimR", 120), CVar_GetS32("gCCStartBtnPrimG", 120), CVar_GetS32("gCCStartBtnPrimB", 120), interfaceCtx->startAlpha);
             }
-            gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]) << 2, 68,
-                                (OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]) + 22) << 2, 156,
+            gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]+Right_HUD_Margin) << 2, 68+((Top_HUD_Margin*-1)*4),
+                                (OTRGetRectDimensionFromRightEdge(startButtonLeftPos[gSaveContext.language]+Right_HUD_Margin) + 22) << 2, 156+((Top_HUD_Margin*-1)*4),
                                 G_TX_RENDERTILE, 0, 0, 1462, 1462);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->startAlpha);
@@ -2879,11 +2884,11 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             dxdy = (1 << 10) / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
             width = DO_ACTION_TEX_WIDTH / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
             height = DO_ACTION_TEX_HEIGHT / (R_START_LABEL_DD(gSaveContext.language) / 100.0f);
-            const s16 rStartLabelX = OTRGetRectDimensionFromRightEdge(R_START_LABEL_X(gSaveContext.language));
+            const s16 rStartLabelX = OTRGetRectDimensionFromRightEdge(R_START_LABEL_X(gSaveContext.language)+Right_HUD_Margin);
             gSPWideTextureRectangle(
                 OVERLAY_DISP++, rStartLabelX << 2,
-                R_START_LABEL_Y(gSaveContext.language) << 2, (rStartLabelX + width) << 2,
-                (R_START_LABEL_Y(gSaveContext.language) + height) << 2, G_TX_RENDERTILE, 0, 0, dxdy, dxdy);
+                R_START_LABEL_Y(gSaveContext.language)+(Top_HUD_Margin*-1) << 2, (rStartLabelX + width) << 2,
+                (R_START_LABEL_Y(gSaveContext.language)+(Top_HUD_Margin*-1) + height) << 2, G_TX_RENDERTILE, 0, 0, dxdy, dxdy);
         }
     }
 
@@ -2902,8 +2907,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                 temp = interfaceCtx->healthAlpha;
             }
 
-            const s16 rCUpBtnX  = OTRGetRectDimensionFromRightEdge(R_C_UP_BTN_X);
-            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X);
+            const s16 rCUpBtnX  = OTRGetRectDimensionFromRightEdge(R_C_UP_BTN_X+Right_HUD_Margin);
+            const s16 rCUPIconX = OTRGetRectDimensionFromRightEdge(R_C_UP_ICON_X+Right_HUD_Margin);
             if (CVar_GetS32("gHudColors", 1) == 0) {
               gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), temp);
             } else if (CVar_GetS32("gHudColors", 1) == 1) {
@@ -2912,8 +2917,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
               gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), temp);
             }
             gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-            gSPWideTextureRectangle(OVERLAY_DISP++, rCUpBtnX << 2, R_C_UP_BTN_Y << 2, (rCUpBtnX + 16) << 2,
-                                (R_C_UP_BTN_Y + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
+            gSPWideTextureRectangle(OVERLAY_DISP++, rCUpBtnX << 2, R_C_UP_BTN_Y+(Top_HUD_Margin*-1) << 2, (rCUpBtnX + 16) << 2,
+                                (R_C_UP_BTN_Y+(Top_HUD_Margin*-1) + 16) << 2, G_TX_RENDERTILE, 0, 0, 2 << 10, 2 << 10);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, temp);
             gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
@@ -2924,8 +2929,8 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                    G_TX_NOLOD, G_TX_NOLOD);
             gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
-            gSPWideTextureRectangle(OVERLAY_DISP++, rCUPIconX << 2, R_C_UP_ICON_Y << 2, (rCUPIconX + 32) << 2,
-                                (R_C_UP_ICON_Y + 8) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+            gSPWideTextureRectangle(OVERLAY_DISP++, rCUPIconX << 2, R_C_UP_ICON_Y+(Top_HUD_Margin*-1) << 2, (rCUPIconX + 32) << 2,
+                                (R_C_UP_ICON_Y+(Top_HUD_Margin*-1) + 8) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
         }
 
         sCUpTimer--;
@@ -2959,7 +2964,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             }
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32,
-                                          OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(temp)), R_ITEM_BTN_Y(temp), R_ITEM_BTN_WIDTH(temp),
+                                          OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(temp)+Right_HUD_Margin), R_ITEM_BTN_Y(temp)+(Top_HUD_Margin*-1), R_ITEM_BTN_WIDTH(temp),
                                           R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
 
             const char* cButtonIcons[] = { gButtonBackgroundTex, gEquippedItemOutlineTex, gEmptyCLeftArrowTex,
@@ -2967,7 +2972,7 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
             };
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, cButtonIcons[(temp + 1)], 32, 32,
-                                          OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(temp)), R_ITEM_BTN_Y(temp), R_ITEM_BTN_WIDTH(temp),
+                                          OTRGetRectDimensionFromRightEdge(R_ITEM_BTN_X(temp)+Right_HUD_Margin), R_ITEM_BTN_Y(temp)+(Top_HUD_Margin*-1), R_ITEM_BTN_WIDTH(temp),
                                           R_ITEM_BTN_WIDTH(temp), R_ITEM_BTN_DD(temp) << 1, R_ITEM_BTN_DD(temp) << 1);
         }
     }
@@ -2982,9 +2987,9 @@ void Interface_DrawItemIconTexture(GlobalContext* globalCtx, void* texture, s16 
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
     // gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
     gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
-    gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(R_ITEM_ICON_X(button)) << 2, R_ITEM_ICON_Y(button) << 2,
-                        (OTRGetRectDimensionFromRightEdge(R_ITEM_ICON_X(button)) + R_ITEM_ICON_WIDTH(button)) << 2,
-                        (R_ITEM_ICON_Y(button) + R_ITEM_ICON_WIDTH(button)) << 2, G_TX_RENDERTILE, 0, 0,
+    gSPWideTextureRectangle(OVERLAY_DISP++, OTRGetRectDimensionFromRightEdge(R_ITEM_ICON_X(button)+Right_HUD_Margin) << 2, R_ITEM_ICON_Y(button)+(Top_HUD_Margin*-1) << 2,
+                        (OTRGetRectDimensionFromRightEdge(R_ITEM_ICON_X(button)+Right_HUD_Margin) + R_ITEM_ICON_WIDTH(button)) << 2,
+                        (R_ITEM_ICON_Y(button)+(Top_HUD_Margin*-1) + R_ITEM_ICON_WIDTH(button)) << 2, G_TX_RENDERTILE, 0, 0,
                         R_ITEM_ICON_DD(button) << 1, R_ITEM_ICON_DD(button) << 1);
 
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_parameter.c", 3094);
@@ -3046,11 +3051,11 @@ void Interface_DrawAmmoCount(GlobalContext* globalCtx, s16 button, s16 alpha) {
 
         if (i != 0) {
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[i], 8, 8,
-                                          OTRGetRectDimensionFromRightEdge(R_ITEM_AMMO_X(button)), R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+                                          OTRGetRectDimensionFromRightEdge(R_ITEM_AMMO_X(button)+Right_HUD_Margin), R_ITEM_AMMO_Y(button)+(Top_HUD_Margin*-1), 8, 8, 1 << 10, 1 << 10);
         }
 
         OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[ammo], 8, 8,
-                                      OTRGetRectDimensionFromRightEdge(R_ITEM_AMMO_X(button)) + 6, R_ITEM_AMMO_Y(button), 8, 8, 1 << 10, 1 << 10);
+                                      OTRGetRectDimensionFromRightEdge(R_ITEM_AMMO_X(button)+Right_HUD_Margin) + 6, R_ITEM_AMMO_Y(button)+(Top_HUD_Margin*-1), 8, 8, 1 << 10, 1 << 10);
         gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_BILERP | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
     }
     CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_parameter.c", 3158);
@@ -3275,8 +3280,8 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, rColor[0], rColor[1], rColor[2], interfaceCtx->magicAlpha);
                 gDPSetEnvColor(OVERLAY_DISP++, 0, 80, 0, 255);
             }
-            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26),
-                                          206, 16, 16, 1 << 10, 1 << 10);
+            OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26+(Left_HUD_Margin*-1)),
+                                          206+(Bottom_HUD_Margin), 16, 16, 1 << 10, 1 << 10);
 
             switch (globalCtx->sceneNum) {
                 case SCENE_BMORI1:
@@ -3298,7 +3303,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                         gDPPipeSync(OVERLAY_DISP++);
                         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 200, 230, 255, interfaceCtx->magicAlpha);
                         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 20, 255);
-                        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gSmallKeyCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26), 190, 16, 16,
+                        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gSmallKeyCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26+(Left_HUD_Margin*-1)), 190+(Bottom_HUD_Margin), 16, 16,
                                                       1 << 10, 1 << 10);
 
                         // Small Key Counter
@@ -3315,7 +3320,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                             interfaceCtx->counterDigits[3] -= 10;
                         }
 
-                        svar3 = OTRGetRectDimensionFromLeftEdge(42);
+                        svar3 = OTRGetRectDimensionFromLeftEdge(42+(Left_HUD_Margin*-1));
 
                         if (interfaceCtx->counterDigits[2] != 0) {
                             OVERLAY_DISP = Gfx_TextureI8(OVERLAY_DISP, ((u8*)((u8*)digitTextures[interfaceCtx->counterDigits[2]])), 8,
@@ -3325,7 +3330,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
                         OVERLAY_DISP = Gfx_TextureI8(OVERLAY_DISP,
                                                     ((u8*)digitTextures[interfaceCtx->counterDigits[3]]), 8, 16,
-                                          svar3, 190, 8, 16, 1 << 10, 1 << 10);
+                                          svar3, 190+(Bottom_HUD_Margin), 8, 16, 1 << 10, 1 << 10);
                     }
                     break;
                 default:
@@ -3369,7 +3374,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
             for (svar1 = 0, svar3 = 42; svar1 < svar5; svar1++, svar2++, svar3 += 8) {
                 OVERLAY_DISP =
                     Gfx_TextureI8(OVERLAY_DISP, ((u8*)digitTextures[interfaceCtx->counterDigits[svar2]]), 8, 16,
-                        OTRGetRectDimensionFromLeftEdge(svar3), 206, 8, 16, 1 << 10, 1 << 10);
+                        OTRGetRectDimensionFromLeftEdge(svar3+(Left_HUD_Margin*-1)), 206+(Bottom_HUD_Margin), 8, 16, 1 << 10, 1 << 10);
             }
         } else {
             // Make sure item counts have black backgrounds
@@ -3431,8 +3436,8 @@ void Interface_Draw(GlobalContext* globalCtx) {
             gDPSetOtherMode(OVERLAY_DISP++, G_AD_DISABLE | G_CD_DISABLE | G_CK_NONE | G_TC_FILT | G_TF_POINT | G_TT_IA16 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE, G_AC_NONE | G_ZS_PRIM | G_RM_XLU_SURF | G_RM_XLU_SURF2);
             R_B_LABEL_DD = (1 << 10) / (WREG(37 + gSaveContext.language) / 100.0f);
 
-            const s16 rBLabelX = OTRGetRectDimensionFromRightEdge(R_B_LABEL_X(gSaveContext.language));
-            gSPWideTextureRectangle(OVERLAY_DISP++, rBLabelX << 2, R_B_LABEL_Y(gSaveContext.language) << 2,
+            const s16 rBLabelX = OTRGetRectDimensionFromRightEdge(R_B_LABEL_X(gSaveContext.language)+Right_HUD_Margin);
+            gSPWideTextureRectangle(OVERLAY_DISP++, rBLabelX << 2, R_B_LABEL_Y(gSaveContext.language)+(Top_HUD_Margin*-1) << 2,
                                 (rBLabelX + DO_ACTION_TEX_WIDTH) << 2,
                                 (R_B_LABEL_Y(gSaveContext.language) + DO_ACTION_TEX_HEIGHT) << 2, G_TX_RENDERTILE, 0, 0,
                                 R_B_LABEL_DD, R_B_LABEL_DD);
@@ -3480,7 +3485,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
 
         // A Button
         func_80094A14(globalCtx->state.gfxCtx);
-        const f32 rABtnX = OTRGetDimensionFromRightEdge(R_A_BTN_X);
+        const f32 rABtnX = OTRGetDimensionFromRightEdge(R_A_BTN_X+Right_HUD_Margin);
         //func_8008A8B8(globalCtx, R_A_BTN_Y, R_A_BTN_Y + 45, rABtnX, rABtnX + 45);
         gSPClearGeometryMode(OVERLAY_DISP++, G_CULL_BOTH);
         gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
@@ -3493,10 +3498,10 @@ void Interface_Draw(GlobalContext* globalCtx) {
         }
 
         if (fullUi) {
-            Interface_DrawActionButton(globalCtx, rABtnX, R_A_BTN_Y);
+            Interface_DrawActionButton(globalCtx, rABtnX, R_A_BTN_Y+(Top_HUD_Margin*-1));
         }
         gDPPipeSync(OVERLAY_DISP++);
-        const f32 rAIconX = OTRGetDimensionFromRightEdge(R_A_ICON_X);
+        const f32 rAIconX = OTRGetDimensionFromRightEdge(R_A_ICON_X+Right_HUD_Margin);
         //func_8008A8B8(globalCtx, R_A_ICON_Y, R_A_ICON_Y + 45, rAIconX, rAIconX + 45);
         gSPSetGeometryMode(OVERLAY_DISP++, G_CULL_BACK);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
@@ -3504,7 +3509,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->aAlpha);
 
         gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 0);
-        Matrix_Translate(-138.0f + rAIconX, 98.0f - R_A_ICON_Y, WREG(46 + gSaveContext.language) / 10.0f, MTXMODE_NEW);
+        Matrix_Translate(-138.0f + rAIconX, 98.0f - (R_A_ICON_Y+(Top_HUD_Margin*-1)), WREG(46 + gSaveContext.language) / 10.0f, MTXMODE_NEW);
         Matrix_Scale(1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
         Matrix_RotateX(interfaceCtx->unk_1F4 / 10000.0f, MTXMODE_APPLY);
         gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_parameter.c", 3701),
@@ -4072,6 +4077,18 @@ void Interface_Update(GlobalContext* globalCtx) {
     s16 alpha1;
     u16 action;
     Input* debugInput = &globalCtx->state.input[2];
+
+    if (CVar_GetS32("gHUDMargins", 0) != 0) {
+        Top_HUD_Margin = CVar_GetS32("gHUDMargin_T", 0);
+        Left_HUD_Margin = CVar_GetS32("gHUDMargin_L", 0);
+        Right_HUD_Margin = CVar_GetS32("gHUDMargin_R", 0);
+        Bottom_HUD_Margin = CVar_GetS32("gHUDMargin_B", 0);
+    } else {
+        Top_HUD_Margin = 0;
+        Left_HUD_Margin = 0;
+        Right_HUD_Margin = 0;
+        Bottom_HUD_Margin = 0;
+    }
 
     if (CHECK_BTN_ALL(debugInput->press.button, BTN_DLEFT)) {
         gSaveContext.language = LANGUAGE_ENG;

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3204,6 +3204,50 @@ const char* digitTextures[] =
     gCounterDigit4Tex, gCounterDigit5Tex, gCounterDigit6Tex, gCounterDigit7Tex, gCounterDigit8Tex
 };
 
+void Days_interface(GlobalContext* globalCtx, InterfaceContext* interfaceCtx) {
+    bool fullUi = !CVar_GetS32("gMinimalUI", 0) || !R_MINIMAP_DISABLED || globalCtx->pauseCtx.state != 0;
+    int RectSize_w = 16; //This is the size used for current time to be sure the middle of the icon will be on 12 when it's 12.
+    int RectSize_h = 16;
+    int ScreenXCenter = (SCREEN_WIDTH/2)-RectSize_w;
+    int RectFarLeft = -80;
+    int RectFarRight = 80;
+    int CursorPosition = ((gSaveContext.dayTime/800)*2)-RectFarRight;
+    int Cursor_color[] = {180,180,180};
+    int YposGeneral = 193;
+    int i = 0;
+    //printf("Day time : %d \n",CursorPosition);
+    //gSaveContext.dayTime = CVar_GetS32("gDbgIntVal", 0)*655;
+
+    OPEN_DISPS(globalCtx->state.gfxCtx, "../z_parameter.c", 3405);
+    if (fullUi) {
+        // Left Icon
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->magicAlpha/2);
+        gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gEmptyCRightArrowTex, 32, 32, ScreenXCenter+RectFarLeft,YposGeneral+2+(Bottom_HUD_Margin), 32, 32, 1 << 10, 1 << 10);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->magicAlpha);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[0], 8, 8, ScreenXCenter+RectFarLeft+11, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[0], 8, 8, ScreenXCenter+RectFarLeft+16, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+
+        // Right Icon
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->magicAlpha/2);
+        gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gEmptyCLeftArrowTex, 32, 32, ScreenXCenter+RectFarRight+2,YposGeneral+2+(Bottom_HUD_Margin), 32, 32, 1 << 10, 1 << 10);
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->magicAlpha);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[1], 8, 8, ScreenXCenter+RectFarRight+13, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[2], 8, 8, ScreenXCenter+RectFarRight+17, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+
+        // Center icons
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[1], 8, 8, ScreenXCenter+RectSize_w-6, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, (u8*)_gAmmoDigit0Tex[2], 8, 8, ScreenXCenter+RectSize_w-1, YposGeneral+(Bottom_HUD_Margin), 8, 8, 1 << 10, 1 << 10);
+
+        // Cursor Icon
+        gDPSetPrimColor(OVERLAY_DISP++, 0, 0, Cursor_color[0], Cursor_color[1], Cursor_color[2], interfaceCtx->magicAlpha/2);
+        gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+        OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gEmptyCDownArrowTex, 32, 32, ScreenXCenter+CursorPosition,YposGeneral-1+(Bottom_HUD_Margin), 32, 32, 1 << 10, 1 << 10);
+
+    }
+    CLOSE_DISPS(globalCtx->state.gfxCtx, "../z_parameter.c", 4269);
+}
 void Interface_Draw(GlobalContext* globalCtx) {
     static s16 magicArrowEffectsR[] = { 255, 100, 255 };
     static s16 magicArrowEffectsG[] = { 0, 100, 255 };
@@ -3265,6 +3309,26 @@ void Interface_Draw(GlobalContext* globalCtx) {
         func_80094520(globalCtx->state.gfxCtx);
 
         if (fullUi) {
+            PauseContext* pauseCtx = &globalCtx->pauseCtx;
+            if(CVar_GetS32("gShowClock", 0) != 0){
+                //Day cycle interface. (useless ... ?)
+                Days_interface(globalCtx, interfaceCtx);
+            }
+            /*if(CVar_GetS32("gAlwaysTick", 0) != 0 && pauseCtx->state >= 1){
+                if(CVar_GetS32("gTickMultiplier", 0) != 0 && CVar_GetS32("gDivideTime", 0) != 0){
+                    gSaveContext.dayTime += (CVar_GetS32("gTickMultiplier", 0)/3);
+                    gSaveContext.skyboxTime += (CVar_GetS32("gTickMultiplier", 0)/3);
+                } else if(CVar_GetS32("gTickMultiplier", 0) != 0 && CVar_GetS32("gDivideTime", 0) != 1){
+                    gSaveContext.dayTime += (CVar_GetS32("gTickMultiplier", 0)/3);
+                    gSaveContext.skyboxTime += (CVar_GetS32("gTickMultiplier", 0)/3);
+                } else if(CVar_GetS32("gTickMultiplier", 0) == 0 ) {
+                    gSaveContext.dayTime = gSaveContext.dayTime;
+                } else {
+                    gSaveContext.dayTime += 2.0f;
+                    gSaveContext.skyboxTime += 2.0f;
+                }
+            }*/
+            
             // Rupee Icon
             s16* rColor;
 

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2940,15 +2940,22 @@ void Interface_DrawItemButtons(GlobalContext* globalCtx) {
     // Empty C Button Arrows
     for (temp = 1; temp < 4; temp++) {
         if (gSaveContext.equips.buttonItems[temp] > 0xF0) {
+            
             if (temp == 1) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cLeftAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cLeftAlpha);
+                if (CVar_GetS32("gHudColors", 1) == 2) {
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), interfaceCtx->cLeftAlpha);
+                }
             } else if (temp == 2) {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cDownAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cDownAlpha);
+                if (CVar_GetS32("gHudColors", 1) == 2) {
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), interfaceCtx->cDownAlpha);
+                }
             } else {
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2),
-                                interfaceCtx->cRightAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, R_C_BTN_COLOR(0), R_C_BTN_COLOR(1), R_C_BTN_COLOR(2), interfaceCtx->cRightAlpha);
+                if (CVar_GetS32("gHudColors", 1) == 2) {
+                    gDPSetPrimColor(OVERLAY_DISP++, 0, 0, CVar_GetS32("gCCCBtnPrimR", 255), CVar_GetS32("gCCCBtnPrimG", 160), CVar_GetS32("gCCCBtnPrimB", 0), interfaceCtx->cRightAlpha);
+                }
             }
 
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, ((u8*)gButtonBackgroundTex), 32, 32,

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -3283,6 +3283,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
             OVERLAY_DISP = Gfx_TextureIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, OTRGetRectDimensionFromLeftEdge(26+(Left_HUD_Margin*-1)),
                                           206+(Bottom_HUD_Margin), 16, 16, 1 << 10, 1 << 10);
 
+
             switch (globalCtx->sceneNum) {
                 case SCENE_BMORI1:
                 case SCENE_HIDAN:

--- a/soh/src/code/z_room.c
+++ b/soh/src/code/z_room.c
@@ -295,12 +295,15 @@ void func_8009638C(Gfx** displayList, void* source, void* tlut, u16 width, u16 h
         bg->b.frameH = height * 4;
         guS2DInitBg(bg);
         
-        gDPSetOtherMode(displayListHead++, mode0 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
+        gDPSetOtherMode(displayListHead++, mode0 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_FILL | G_PM_NPRIMITIVE,
                         G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
 
         gDPSetFillColor(displayListHead++, GPACK_RGBA5551(0, 0, 0, 1) << 16 | GPACK_RGBA5551(0, 0, 0, 1));
         gDPFillWideRectangle(displayListHead++, OTRGetRectDimensionFromLeftEdge(0), 0,
                          OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH), SCREEN_HEIGHT);
+
+        gDPSetOtherMode(displayListHead++, mode0 | G_TL_TILE | G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
+                        G_AC_THRESHOLD | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
 
         gDPLoadMultiTile(displayListHead++, bg->b.imagePtr, 0,
             G_TX_RENDERTILE, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, 0, 0, 0, 0 + 31,

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -363,13 +363,22 @@ void Sram_OpenSave(SramContext* sramCtx) {
             gSaveContext.entranceIndex = 0x41B;
             break;
 
-        default:
+        case SCENE_KAKUSIANA:
             if (gSaveContext.savedSceneNum != SCENE_LINK_HOME) {
                 gSaveContext.entranceIndex = (LINK_AGE_IN_YEARS == YEARS_CHILD) ? 0xBB : 0x5F4;
             } else {
                 gSaveContext.entranceIndex = 0xBB;
             }
             break;
+        default:
+            if (!CVar_GetS32("gSaveEntrance", 0)) {
+                if (gSaveContext.savedSceneNum != SCENE_LINK_HOME) {
+                    gSaveContext.entranceIndex = (LINK_AGE_IN_YEARS == YEARS_CHILD) ? 0xBB : 0x5F4;
+                } else {
+                    gSaveContext.entranceIndex = 0xBB;
+                }
+                break;
+            }
     }
 
     osSyncPrintf("scene_no = %d\n", gSaveContext.entranceIndex);

--- a/soh/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot06_Objects/z_bg_spot06_objects.c
@@ -167,6 +167,7 @@ void BgSpot06Objects_Init(Actor* thisx, GlobalContext* globalCtx) {
             } else {
                 this->lakeHyliaWaterLevel = 0.0f;
                 WaterBox* water_boxes = globalCtx->colCtx.colHeader->waterBoxes;
+                water_boxes[LHWB_GERUDO_VALLEY_RIVER_LOWER].ySurface = WATER_LEVEL_RIVER_RAISED;
                 water_boxes[LHWB_MAIN_1].ySurface = WATER_LEVEL_RAISED;
                 water_boxes[LHWB_MAIN_2].ySurface = WATER_LEVEL_RAISED;
                 this->actionFunc = BgSpot06Objects_DoNothing;

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -418,7 +418,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, GlobalContext* globalCtx) {
             if (this->unk_198 == 0x5A) {
                 if (!(gSaveContext.eventChkInf[7] & 2)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40, true);
                 }
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_FIRE_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Dodongo/z_boss_dodongo.c
@@ -418,7 +418,7 @@ void BossDodongo_IntroCutscene(BossDodongo* this, GlobalContext* globalCtx) {
             if (this->unk_198 == 0x5A) {
                 if (!(gSaveContext.eventChkInf[7] & 2)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gKingDodongoTitleCardTex), 160, 180, 128, 40);
                 }
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_FIRE_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -493,7 +493,7 @@ void BossFd_Fly(BossFd* this, GlobalContext* globalCtx) {
                 }
                 if ((this->timers[3] == 130) && !(gSaveContext.eventChkInf[7] & 8)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40, true);
                 }
                 if (this->timers[3] <= 100) {
                     this->camData.eyeVel.x = this->camData.eyeVel.y = this->camData.eyeVel.z = 2.0f;

--- a/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/soh/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -493,7 +493,7 @@ void BossFd_Fly(BossFd* this, GlobalContext* globalCtx) {
                 }
                 if ((this->timers[3] == 130) && !(gSaveContext.eventChkInf[7] & 8)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gVolvagiaBossTitleCardTex), 160, 180, 128, 40);
                 }
                 if (this->timers[3] <= 100) {
                     this->camData.eyeVel.x = this->camData.eyeVel.y = this->camData.eyeVel.z = 2.0f;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1088,7 +1088,7 @@ void BossGanon_IntroCutscene(BossGanon* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x100)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 39);
                 }
 
                 gSaveContext.eventChkInf[7] |= 0x100;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1088,7 +1088,7 @@ void BossGanon_IntroCutscene(BossGanon* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x100)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 39);
+                                           SEGMENTED_TO_VIRTUAL(gDorfTitleCardTex), 160, 180, 128, 40, false);
                 }
 
                 gSaveContext.eventChkInf[7] |= 0x100;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -671,7 +671,8 @@ void func_808FD5F4(BossGanon2* this, GlobalContext* globalCtx) {
             if (this->unk_398 == 80) {
                 BossGanon2_SetObjectSegment(this, globalCtx, OBJECT_GANON2, false);
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(object_ganon2_Tex_021A90), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(object_ganon2_Tex_021A90), 160, 180, 128, 40, true);
+                                       //It has translation but they are all the same. they all say "GANON" only
             }
             this->unk_3A4.x = ((this->actor.world.pos.x + 500.0f) - 350.0f) + 100.0f;
             this->unk_3A4.y = this->actor.world.pos.y;

--- a/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -926,7 +926,7 @@ void BossGoma_Encounter(BossGoma* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 1)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40, true);
                 }
 
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);

--- a/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
+++ b/soh/src/overlays/actors/ovl_Boss_Goma/z_boss_goma.c
@@ -926,7 +926,7 @@ void BossGoma_Encounter(BossGoma* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 1)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gGohmaTitleCardTex), 160, 180, 128, 40);
                 }
 
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);

--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1423,7 +1423,7 @@ void BossMo_IntroCs(BossMo* this, GlobalContext* globalCtx) {
             }
             if (this->timers[2] == 130) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40, true);
                 gSaveContext.eventChkInf[7] |= 0x10;
             }
             break;

--- a/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
+++ b/soh/src/overlays/actors/ovl_Boss_Mo/z_boss_mo.c
@@ -1423,7 +1423,7 @@ void BossMo_IntroCs(BossMo* this, GlobalContext* globalCtx) {
             }
             if (this->timers[2] == 130) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                       SEGMENTED_TO_VIRTUAL(gMorphaTitleCardTex), 160, 180, 128, 40);
                 gSaveContext.eventChkInf[7] |= 0x10;
             }
             break;

--- a/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
+++ b/soh/src/overlays/actors/ovl_Boss_Sst/z_boss_sst.c
@@ -598,7 +598,7 @@ void BossSst_HeadIntro(BossSst* this, GlobalContext* globalCtx) {
                 } else if (revealStateTimer == 85) {
                     if (!(gSaveContext.eventChkInf[7] & 0x80)) {
                         TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                               SEGMENTED_TO_VIRTUAL(gBongoTitleCardTex), 160, 180, 128, 40);
+                                               SEGMENTED_TO_VIRTUAL(gBongoTitleCardTex), 160, 180, 128, 40, true);
                     }
                     Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);
                     Animation_MorphToPlayOnce(&this->skelAnime, &gBongoHeadEyeCloseAnim, -5.0f);

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -2220,7 +2220,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, GlobalContext* globalCtx) {
                 globalCtx->envCtx.unk_BE = 1;
                 globalCtx->envCtx.unk_BD = 1;
                 globalCtx->envCtx.unk_D8 = 0.0f;
-                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40);
+                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40, true);
                 gSaveContext.eventChkInf[7] |= 0x20;
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
+++ b/soh/src/overlays/actors/ovl_Boss_Tw/z_boss_tw.c
@@ -2220,7 +2220,7 @@ void BossTw_TwinrovaIntroCS(BossTw* this, GlobalContext* globalCtx) {
                 globalCtx->envCtx.unk_BE = 1;
                 globalCtx->envCtx.unk_BD = 1;
                 globalCtx->envCtx.unk_D8 = 0.0f;
-                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40); // OTRTODO
+                TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx, SEGMENTED_TO_VIRTUAL(gTwinrovaTitleCardTex), 160, 180, 128, 40);
                 gSaveContext.eventChkInf[7] |= 0x20;
                 Audio_QueueSeqCmd(SEQ_PLAYER_BGM_MAIN << 24 | NA_BGM_BOSS);
             }

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -979,7 +979,7 @@ void BossVa_BodyIntro(BossVa* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x40)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40);
+                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40, true);
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {

--- a/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/soh/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -979,7 +979,7 @@ void BossVa_BodyIntro(BossVa* this, GlobalContext* globalCtx) {
 
                 if (!(gSaveContext.eventChkInf[7] & 0x40)) {
                     TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 0xA0, 0xB4, 0x80, 0x28);
+                                           SEGMENTED_TO_VIRTUAL(gBarinadeTitleCardTex), 160, 180, 128, 40);
                 }
 
                 if (Rand_ZeroOne() < 0.1f) {

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -117,7 +117,6 @@ void EnBom_Init(Actor* thisx, GlobalContext* globalCtx) {
 
 void EnBom_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     EnBom* this = (EnBom*)thisx;
-
     Collider_DestroyJntSph(globalCtx, &this->explosionCollider);
     Collider_DestroyCylinder(globalCtx, &this->bombCollider);
 }
@@ -216,7 +215,6 @@ void EnBom_Explode(EnBom* this, GlobalContext* globalCtx) {
             player->interactRangeActor = NULL;
             player->stateFlags1 &= ~0x800;
         }
-
         Actor_Kill(&this->actor);
     }
 }
@@ -275,7 +273,6 @@ void EnBom_Update(Actor* thisx, GlobalContext* globalCtx2) {
         // double bomb flash speed and adjust red color at certain times during the countdown
         if ((this->timer == 3) || (this->timer == 20) || (this->timer == 40)) {
             thisx->shape.rot.z = 0;
-            Actor_SetColorFilter(&this->actor, 0x4000, 0xFF, 0x2000, 0x50);
             this->flashSpeedScale >>= 1;
         }
         if ((this->timer < 100) && ((this->timer & (this->flashSpeedScale + 1)) != 0)) {
@@ -283,7 +280,7 @@ void EnBom_Update(Actor* thisx, GlobalContext* globalCtx2) {
         } else {
             Math_SmoothStepToF(&this->flashIntensity, 0.0f, 1.0f, 140.0f / this->flashSpeedScale, 0.0f);
         }
-        Actor_SetColorFilter(&this->actor,0x4000,this->flashIntensity,0,8);
+        
 
         //printf("%f \n",this->flashIntensity);
         if (this->timer < 3) {
@@ -342,36 +339,9 @@ void EnBom_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_bom.c", 913);
     frames = globalCtx->gameplayFrames;
     if (thisx->params == BOMB_BODY) {
-        //POLY_XLU_DISP = func_800937C0(POLY_XLU_DISP);
-        //func_80093D18(globalCtx->state.gfxCtx);
-        //Matrix_ReplaceRotation(&globalCtx->billboardMtxF);
-        //func_8002EBCC(thisx, globalCtx, 0);
-
-        //gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_en_bom.c", 928), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        //gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
-        //Matrix_RotateZYX(0x4000, 0, 0, MTXMODE_APPLY);
-
         Matrix_Translate(0.0f, -670.0f, 0.0f, MTXMODE_APPLY);
-        //gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, 0, 255, 255, 255);
-        //gDPPipeSync(POLY_XLU_DISP++);
-        //gSPTexture(POLY_XLU_DISP++, 0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON);
-        //gDPSetEnvColor(POLY_XLU_DISP++, 0, 255, 255, 255);
-        //gDPSetBlendColor(POLY_XLU_DISP++, 0, 255, 255, 255);
-        //gDPSetAlphaDither(POLY_XLU_DISP++, G_AD_DISABLE);
-        //gDPSetColorDither(POLY_XLU_DISP++, G_CD_DISABLE);
-        //gDPSetRenderMode(POLY_XLU_DISP++, G_RM_PASS, G_RM_AA_ZB_XLU_SURF2);
         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_en_bom.c", 648), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-
         gSPDisplayList(POLY_XLU_DISP++, gGiBombDL);
-        Actor_SetColorFilter(&this->actor,0x4000,this->flashIntensity,0,8);
-        //gDPPipeSync(POLY_OPA_DISP++);
-        //gSPDisplayList(POLY_XLU_DISP++, gGiZoraSapphireSettingDL);
-
-        
-
-        //gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx, "../z_en_bom.c", 934), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        //gSPDisplayList(POLY_XLU_DISP++, gGiBombDL);
-        //Actor_SetColorFilter(&this->actor, 0, 255, 0, 12);
         Collider_UpdateSpheres(0, &this->explosionCollider);
         //
     }

--- a/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.h
+++ b/soh/src/overlays/actors/ovl_En_Bom/z_en_bom.h
@@ -17,6 +17,8 @@ typedef struct EnBom {
     /* 0x01FA */ s16 flashSpeedScale;
     /* 0x01FC */ f32 flashIntensity;
     /* 0x0200 */ u8 bumpOn;
+    /* 0x0150 */ LightInfo lightInfo;
+    /* 0x0160 */ LightNode* lightNode;
     /* 0x0204 */ EnBomActionFunc actionFunc;
     Color_RGBA8 flashColor;
     u8 unk_19E;

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -94,8 +94,7 @@ s32 func_80B0BE20(EnSw* this, CollisionPoly* poly) {
     EnSw_CrossProduct(&this->unk_370, &sp44, &this->unk_37C);
     temp_f0 = Math3D_Vec3fMagnitude(&this->unk_37C);
     if (temp_f0 < 0.001f) {
-        temp_f0 = 0.001f;
-        //return 1;
+        return 0;
     }
     this->unk_37C.x = this->unk_37C.x * (1.0f / temp_f0);
     this->unk_37C.y = this->unk_37C.y * (1.0f / temp_f0);
@@ -118,8 +117,7 @@ s32 func_80B0BE20(EnSw* this, CollisionPoly* poly) {
     this->unk_3D8.zw = 0.0f;
     this->unk_3D8.ww = 1.0f;
     Matrix_MtxFToYXZRotS(&this->unk_3D8, &this->actor.world.rot, 0);
-    //! @bug: Does not return.
-    return 1;
+    //! @bug: Does not return. <- then do it ?!
 }
 
 CollisionPoly* func_80B0C020(GlobalContext* globalCtx, Vec3f* arg1, Vec3f* arg2, Vec3f* arg3, s32* arg4) {
@@ -249,7 +247,7 @@ void EnSw_Init(Actor* thisx, GlobalContext* globalCtx) {
     Collider_SetJntSph(globalCtx, &this->collider, &this->actor, &sJntSphInit, this->sphs);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(0xE), &D_80B0F074);
     this->actor.scale.x = 0.02f;
-
+    
     if (((thisx->params & 0xE000) >> 0xD) == 0) {
         this->actor.world.rot.x = 0;
         this->actor.world.rot.z = 0;
@@ -396,21 +394,21 @@ s32 func_80B0CCF4(EnSw* this, f32* arg1, GlobalContext* globalCtx) {
     MtxF sp2C;
 
     if (this->actor.floorPoly == NULL) {
-        return true;
-    } else {
-        floorPoly = this->actor.floorPoly;
-        floorPolyNormal.x = COLPOLY_GET_NORMAL(floorPoly->normal.x);
-        floorPolyNormal.y = COLPOLY_GET_NORMAL(floorPoly->normal.y);
-        floorPolyNormal.z = COLPOLY_GET_NORMAL(floorPoly->normal.z);
-        Matrix_RotateAxis(*arg1, &floorPolyNormal, MTXMODE_NEW);
-        Matrix_MultVec3f(&this->unk_370, &floorPolyNormal);
+        return false;
     }
+
+    floorPoly = this->actor.floorPoly;
+    floorPolyNormal.x = COLPOLY_GET_NORMAL(floorPoly->normal.x);
+    floorPolyNormal.y = COLPOLY_GET_NORMAL(floorPoly->normal.y);
+    floorPolyNormal.z = COLPOLY_GET_NORMAL(floorPoly->normal.z);
+    Matrix_RotateAxis(*arg1, &floorPolyNormal, MTXMODE_NEW);
+    Matrix_MultVec3f(&this->unk_370, &floorPolyNormal);
+    
     this->unk_370 = floorPolyNormal;
     EnSw_CrossProduct(&this->unk_370, &this->unk_364, &this->unk_37C);
     temp_f0 = Math3D_Vec3fMagnitude(&this->unk_37C);
     if (temp_f0 < 0.001f) {
-        temp_f0 = 0.002f;
-        //return true;
+        return false;
     }
     temp_f0 = 1.0f / temp_f0;
     this->unk_37C.x *= temp_f0;
@@ -897,6 +895,23 @@ void EnSw_Update(Actor* thisx, GlobalContext* globalCtx) {
     func_80B0C9F0(this, globalCtx); //Death function, to set colors etc.
     this->actionFunc(this, globalCtx);
     func_80B0CBE8(this, globalCtx);
+
+    if (this->actor.floorPoly == NULL) {
+        printf("[Error : floorPoly is NULL][Coordinates: X:%f | Y:%f | Z:%f][Rotation: X:%d | Y:%d | Z:%d]\n",
+            this->actor.home.pos.x,this->actor.home.pos.y,this->actor.home.pos.z,
+            thisx->shape.rot.x,thisx->shape.rot.y,thisx->shape.rot.z);
+
+
+            this->actor.world.pos.z -= 0.8f;
+        
+    } else {
+        if (this->actor.home.pos.y < 270 && this->actor.home.pos.y < 265) {
+            //printf("[Shape Rotation: X:%d | Y:%d | Z:%d]\n",      thisx->shape.rot.x,     thisx->shape.rot.y,     thisx->shape.rot.z);
+            //printf("[Home  Rotation: X:%d | Y:%d | Z:%d]\n",  this->actor.home.rot.x, this->actor.home.rot.y, this->actor.home.rot.z);
+            //printf("[World Rotation: X:%d | Y:%d | Z:%d]\n", this->actor.world.rot.x,this->actor.world.rot.y,this->actor.world.rot.z);
+        }
+        
+    }
 }
 
 s32 EnSw_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -305,7 +305,6 @@ void EnSw_Init(Actor* thisx, GlobalContext* globalCtx) {
     } else {
         this->actionFunc = func_80B0D590;
     }
-
 }
 
 void EnSw_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -807,12 +806,7 @@ s32 func_80B0E430(EnSw* this, f32 arg1, s16 arg2, s32 arg3, GlobalContext* globa
     } else {
         this->unk_440 = 0;
     }
-    if (this->actor.wallPoly == NULL && this->actor.floorPoly == NULL){
-        Math_SmoothStepToS(&this->actor.shape.rot.y, this->unk_444, 4, arg2, arg2);
-    } else {
-        Math_SmoothStepToS(&this->actor.shape.rot.z, this->unk_444, 4, arg2, arg2);
-    }
-
+    Math_SmoothStepToS(&this->actor.shape.rot.z, this->unk_444, 4, arg2, arg2);
     this->actor.world.rot = this->actor.shape.rot;
     if (this->actor.shape.rot.z == this->unk_444) {
         return 1;

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -1,8 +1,3 @@
-/*
- * File: z_en_sw.c
- * Overlay: ovl_En_Sw
- * Description: Golden Skulltula
- */
 #include "z_en_sw.h"
 #include "objects/object_st/object_st.h"
 
@@ -117,7 +112,7 @@ s32 func_80B0BE20(EnSw* this, CollisionPoly* poly) {
     this->unk_3D8.zw = 0.0f;
     this->unk_3D8.ww = 1.0f;
     Matrix_MtxFToYXZRotS(&this->unk_3D8, &this->actor.world.rot, 0);
-    //! @bug: Does not return. <- then do it ?!
+    //! @bug: Does not return.
 }
 
 CollisionPoly* func_80B0C020(GlobalContext* globalCtx, Vec3f* arg1, Vec3f* arg2, Vec3f* arg3, s32* arg4) {
@@ -163,7 +158,7 @@ s32 func_80B0C0CC(EnSw* this, GlobalContext* globalCtx, s32 arg2) {
     sp78.z -= this->unk_364.z * 18.0f;
     temp_s1 = func_80B0C020(globalCtx, &sp84, &sp78, &sp90, &sp70);
 
-    if ((temp_s1 != NULL) && (this->velocityY == 0)) {
+    if ((temp_s1 != NULL) && (this->unk_360 == 0)) {
         sp78.x = sp84.x + (this->unk_37C.x * 24);
         sp78.y = sp84.y + (this->unk_37C.y * 24);
         sp78.z = sp84.z + (this->unk_37C.z * 24);
@@ -188,6 +183,7 @@ s32 func_80B0C0CC(EnSw* this, GlobalContext* globalCtx, s32 arg2) {
             if (phi_s1 == 0) {
                 sp78.x = sp84.x - (this->unk_37C.x * 24.0f);
                 sp78.y = sp84.y - (this->unk_37C.y * 24.0f);
+                if (0) {}
                 sp78.z = sp84.z - (this->unk_37C.z * 24.0f);
             } else if (phi_s1 == 1) {
                 sp78.x = sp84.x + (this->unk_370.x * 24.0f);
@@ -247,7 +243,7 @@ void EnSw_Init(Actor* thisx, GlobalContext* globalCtx) {
     Collider_SetJntSph(globalCtx, &this->collider, &this->actor, &sJntSphInit, this->sphs);
     CollisionCheck_SetInfo2(&this->actor.colChkInfo, DamageTable_Get(0xE), &D_80B0F074);
     this->actor.scale.x = 0.02f;
-    
+
     if (((thisx->params & 0xE000) >> 0xD) == 0) {
         this->actor.world.rot.x = 0;
         this->actor.world.rot.z = 0;
@@ -277,7 +273,7 @@ void EnSw_Init(Actor* thisx, GlobalContext* globalCtx) {
     switch ((thisx->params & 0xE000) >> 0xD) {
         case 3:
         case 4:
-            this->velocityY = 1;
+            this->unk_360 = 1;
             this->actor.velocity.y = 8.0f;
             this->actor.speedXZ = 4.0f;
             this->actor.gravity = -1.0f;
@@ -309,6 +305,7 @@ void EnSw_Init(Actor* thisx, GlobalContext* globalCtx) {
     } else {
         this->actionFunc = func_80B0D590;
     }
+
 }
 
 void EnSw_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -317,7 +314,7 @@ void EnSw_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     Collider_DestroyJntSph(globalCtx, &this->collider);
 }
 
-s32 func_80B0C9F0(EnSw* this, GlobalContext* globalCtx) { //Death function, to set colors etc.
+s32 func_80B0C9F0(EnSw* this, GlobalContext* globalCtx) {
     s32 phi_v1 = false;
 
     if (this->actor.xyzDistToPlayerSq < SQ(400.0f) && ((this->actor.params & 0xE000) >> 0xD) == 0 &&
@@ -344,7 +341,7 @@ s32 func_80B0C9F0(EnSw* this, GlobalContext* globalCtx) { //Death function, to s
                 } else {
                     this->unk_420 = -0.1f;
                 }
-                this->unk_394 = 0xA; //Alive state?
+                this->unk_394 = 0xA;
                 this->unk_38A = 1;
                 this->unk_420 *= 4.0f;
                 this->actionFunc = func_80B0D878;
@@ -355,8 +352,9 @@ s32 func_80B0C9F0(EnSw* this, GlobalContext* globalCtx) { //Death function, to s
                 this->actor.shape.shadowScale = 16.0f;
                 this->actor.gravity = -1.0f;
                 this->actor.flags &= ~ACTOR_FLAG_0;
-                this->actionFunc = func_80B0DB00; //function to spawn actor (GS Token here)
+                this->actionFunc = func_80B0DB00;
             }
+
             Audio_PlayActorSound2(&this->actor, NA_SE_EN_STALWALL_DEAD);
             return true;
         }
@@ -387,24 +385,23 @@ void func_80B0CBE8(EnSw* this, GlobalContext* globalCtx) {
     }
 }
 
-s32 func_80B0CCF4(EnSw* this, f32* arg1, GlobalContext* globalCtx) {
-    CollisionPoly* floorPoly;
+s32 func_80B0CCF4(EnSw* this, f32* arg1) {
+    CollisionPoly* temp_v1;
     f32 temp_f0;
-    Vec3f floorPolyNormal;
+    Vec3f sp6C;
     MtxF sp2C;
 
     if (this->actor.floorPoly == NULL) {
         return false;
     }
 
-    floorPoly = this->actor.floorPoly;
-    floorPolyNormal.x = COLPOLY_GET_NORMAL(floorPoly->normal.x);
-    floorPolyNormal.y = COLPOLY_GET_NORMAL(floorPoly->normal.y);
-    floorPolyNormal.z = COLPOLY_GET_NORMAL(floorPoly->normal.z);
-    Matrix_RotateAxis(*arg1, &floorPolyNormal, MTXMODE_NEW);
-    Matrix_MultVec3f(&this->unk_370, &floorPolyNormal);
-    
-    this->unk_370 = floorPolyNormal;
+    temp_v1 = this->actor.floorPoly;
+    sp6C.x = COLPOLY_GET_NORMAL(temp_v1->normal.x);
+    sp6C.y = COLPOLY_GET_NORMAL(temp_v1->normal.y);
+    sp6C.z = COLPOLY_GET_NORMAL(temp_v1->normal.z);
+    Matrix_RotateAxis(*arg1, &sp6C, MTXMODE_NEW);
+    Matrix_MultVec3f(&this->unk_370, &sp6C);
+    this->unk_370 = sp6C;
     EnSw_CrossProduct(&this->unk_370, &this->unk_364, &this->unk_37C);
     temp_f0 = Math3D_Vec3fMagnitude(&this->unk_37C);
     if (temp_f0 < 0.001f) {
@@ -439,7 +436,8 @@ void func_80B0CEA8(EnSw* this, GlobalContext* globalCtx) {
         Camera* activeCam = GET_ACTIVE_CAM(globalCtx);
 
         if (!(Math_Vec3f_DistXYZ(&this->actor.world.pos, &activeCam->eye) >= 380.0f)) {
-            Audio_PlayActorSound2(&this->actor, ((this->actor.params & 0xE000) >> 0xD) > 0 ? NA_SE_EN_STALGOLD_ROLL : NA_SE_EN_STALWALL_ROLL);
+            Audio_PlayActorSound2(&this->actor, ((this->actor.params & 0xE000) >> 0xD) > 0 ? NA_SE_EN_STALGOLD_ROLL
+                                                                                           : NA_SE_EN_STALWALL_ROLL);
         }
     }
 }
@@ -518,7 +516,7 @@ void func_80B0D3AC(EnSw* this, GlobalContext* globalCtx) {
     this->actor.velocity.y = CLAMP_MIN(this->actor.velocity.y, this->actor.minVelocityY);
 
     if (this->actor.velocity.y < 0.0f) {
-        this->velocityY = 0;
+        this->unk_360 = 0;
     }
 
     if (func_80B0C0CC(this, globalCtx, 1) == 1) {
@@ -551,7 +549,7 @@ void func_80B0D590(EnSw* this, GlobalContext* globalCtx) {
 
         Math_ApproachF(&this->actor.scale.x, !IS_DAY ? 0.02f : 0.0f, 0.2f, 0.01f);
         Actor_SetScale(&this->actor, this->actor.scale.x);
-    } 
+    }
 
     if (this->unk_38E != 0) {
         this->unk_38E--;
@@ -591,13 +589,13 @@ void func_80B0D590(EnSw* this, GlobalContext* globalCtx) {
             sp2C = 32768.0f / this->skelAnime.endFrame;
             sp2C *= this->skelAnime.curFrame;
             sp2C = Math_SinS(sp2C) * this->unk_420;
-            func_80B0CCF4(this, &sp2C, globalCtx);
+            func_80B0CCF4(this, &sp2C);
             this->actor.shape.rot = this->actor.world.rot;
         }
     }
 }
 
-void func_80B0D878(EnSw* this, GlobalContext* globalCtx) {// on death stuff like spawning an actor.
+void func_80B0D878(EnSw* this, GlobalContext* globalCtx) {
     Actor* temp_v0;
     Vec3f pos;
     Vec3f velAndAccel = { 0.0f, 0.5f, 0.0f };
@@ -609,7 +607,7 @@ void func_80B0D878(EnSw* this, GlobalContext* globalCtx) {// on death stuff like
         func_80B0CEA8(this, globalCtx);
     }
 
-    func_80B0CCF4(this, &this->unk_420, globalCtx);
+    func_80B0CCF4(this, &this->unk_420);
     this->actor.shape.rot = this->actor.world.rot;
 
     if ((this->unk_394 == 0) && (this->unk_392 == 0)) {
@@ -657,6 +655,7 @@ void func_80B0DB00(EnSw* this, GlobalContext* globalCtx) {
         } else {
             this->actor.velocity.y = ((this->unk_38A--) * 8.0f) * 0.5f;
         }
+
         Audio_PlayActorSound2(&this->actor, NA_SE_EN_DODO_M_GND);
         Actor_SpawnFloorDustRing(globalCtx, &this->actor, &this->actor.world.pos, 16.0f, 0xC, 2.0f, 0x78, 0xA, 0);
     }
@@ -722,7 +721,7 @@ s32 func_80B0DFFC(EnSw* this, GlobalContext* globalCtx) {
         this->collider.base.acFlags &= ~AC_HIT;
         sp4C = false;
     } else if (((globalCtx->state.frames % 4) == 0) &&
-               !BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.world.pos, &this->unk_454, &sp50, &sp60, true, 
+               !BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.world.pos, &this->unk_454, &sp50, &sp60, true,
                                         false, false, true, &sp5C)) {
         sp4C = false;
     } else if (((globalCtx->state.frames % 4) == 1) &&
@@ -732,6 +731,7 @@ s32 func_80B0DFFC(EnSw* this, GlobalContext* globalCtx) {
     } else if (((globalCtx->state.frames % 4) == 2) &&
                !BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.world.pos, &this->unk_46C, &sp50, &sp60, true,
                                         false, false, true, &sp5C)) {
+        if (0) {}
         sp4C = false;
     } else if (((globalCtx->state.frames % 4) == 3) &&
                BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.world.pos, &this->unk_478, &sp50, &sp60, true,
@@ -786,7 +786,7 @@ s32 func_80B0E430(EnSw* this, f32 arg1, s16 arg2, s32 arg3, GlobalContext* globa
     Camera* activeCam;
     f32 lastFrame = Animation_GetLastFrame(&object_st_Anim_000304);
 
-    if (DECR(this->RandOffset1030) != 0) {
+    if (DECR(this->unk_388) != 0) {
         Math_SmoothStepToF(&this->skelAnime.playSpeed, 0.0f, 0.6f, 1000.0f, 0.01f);
         return 0;
     }
@@ -807,9 +807,14 @@ s32 func_80B0E430(EnSw* this, f32 arg1, s16 arg2, s32 arg3, GlobalContext* globa
     } else {
         this->unk_440 = 0;
     }
-    Math_SmoothStepToS(&this->actor.shape.rot.z, this->newShapeRotZ, 4, arg2, arg2);
+    if (this->actor.wallPoly == NULL && this->actor.floorPoly == NULL){
+        Math_SmoothStepToS(&this->actor.shape.rot.y, this->unk_444, 4, arg2, arg2);
+    } else {
+        Math_SmoothStepToS(&this->actor.shape.rot.z, this->unk_444, 4, arg2, arg2);
+    }
+
     this->actor.world.rot = this->actor.shape.rot;
-    if (this->actor.shape.rot.z == this->newShapeRotZ) {
+    if (this->actor.shape.rot.z == this->unk_444) {
         return 1;
     }
     return 0;
@@ -821,14 +826,14 @@ void func_80B0E5E0(EnSw* this, GlobalContext* globalCtx) {
 
     if (func_80B0E430(this, 6.0f, 0x3E8, 1, globalCtx)) {
         rand = Rand_ZeroOne();
-        this->newShapeRotZ =
+        this->unk_444 =
             ((s16)(20000.0f * rand) + 0x2EE0) * (Rand_ZeroOne() >= 0.5f ? 1.0f : -1.0f) + this->actor.world.rot.z;
-        this->RandOffset1030 = Rand_S16Offset(10, 30);
+        this->unk_388 = Rand_S16Offset(10, 30);
     }
 
-    if ((DECR(this->RandOffset2010) == 0) && (func_80B0DEA8(this, globalCtx, 1))) { 
+    if ((DECR(this->unk_442) == 0) && (func_80B0DEA8(this, globalCtx, 1))) {
         Audio_PlayActorSound2(&this->actor, NA_SE_EN_STALWALL_LAUGH);
-        this->RandOffset2010 = 20;
+        this->unk_442 = 20;
         this->actionFunc = func_80B0E728;
     }
 }
@@ -837,23 +842,24 @@ void func_80B0E728(EnSw* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
     s32 pad;
 
-    if (DECR(this->RandOffset2010) != 0) {
+    if (DECR(this->unk_442) != 0) {
         if (func_80B0DEA8(this, globalCtx, 1)) {
             this->unk_448 = player->actor.world.pos;
             this->unk_448.y += 30.0f;
-            this->newShapeRotZ = func_80B0DE34(this, &this->unk_448);
+            this->unk_444 = func_80B0DE34(this, &this->unk_448);
             func_80B0E430(this, 6.0f, (u16)0xFA0, 0, globalCtx);
         } else {
             this->actionFunc = func_80B0E5E0;
         }
     } else {
         if (!func_80B0DFFC(this, globalCtx)) {
-            this->RandOffset2010 = Rand_S16Offset(20, 10);
-            this->newShapeRotZ = func_80B0DE34(this, &this->actor.home.pos);
+            this->unk_442 = Rand_S16Offset(20, 10);
+            this->unk_444 = func_80B0DE34(this, &this->actor.home.pos);
             this->unk_448 = this->actor.home.pos;
             this->actionFunc = func_80B0E9BC;
         } else {
             func_80B0E314(this, this->unk_448, 8.0f);
+
             if (DECR(this->unk_440) == 0) {
                 Audio_PlayActorSound2(&this->actor, NA_SE_EN_STALWALL_DASH);
                 this->unk_440 = 4;
@@ -871,7 +877,7 @@ void func_80B0E90C(EnSw* this, GlobalContext* globalCtx) {
 
     func_80B0E314(this, this->unk_448, 0.0f);
     if (this->actor.speedXZ == 0.0f) {
-        this->newShapeRotZ = func_80B0DE34(this, &this->actor.home.pos);
+        this->unk_444 = func_80B0DE34(this, &this->actor.home.pos);
         this->unk_448 = this->actor.home.pos;
         this->actionFunc = func_80B0E9BC;
     }
@@ -892,26 +898,9 @@ void EnSw_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnSw* this = (EnSw*)thisx;
 
     SkelAnime_Update(&this->skelAnime);
-    func_80B0C9F0(this, globalCtx); //Death function, to set colors etc.
+    func_80B0C9F0(this, globalCtx);
     this->actionFunc(this, globalCtx);
     func_80B0CBE8(this, globalCtx);
-
-    if (this->actor.floorPoly == NULL) {
-        printf("[Error : floorPoly is NULL][Coordinates: X:%f | Y:%f | Z:%f][Rotation: X:%d | Y:%d | Z:%d]\n",
-            this->actor.home.pos.x,this->actor.home.pos.y,this->actor.home.pos.z,
-            thisx->shape.rot.x,thisx->shape.rot.y,thisx->shape.rot.z);
-
-
-            this->actor.world.pos.z -= 0.8f;
-        
-    } else {
-        if (this->actor.home.pos.y < 270 && this->actor.home.pos.y < 265) {
-            //printf("[Shape Rotation: X:%d | Y:%d | Z:%d]\n",      thisx->shape.rot.x,     thisx->shape.rot.y,     thisx->shape.rot.z);
-            //printf("[Home  Rotation: X:%d | Y:%d | Z:%d]\n",  this->actor.home.rot.x, this->actor.home.rot.y, this->actor.home.rot.z);
-            //printf("[World Rotation: X:%d | Y:%d | Z:%d]\n", this->actor.world.rot.x,this->actor.world.rot.y,this->actor.world.rot.z);
-        }
-        
-    }
 }
 
 s32 EnSw_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, void* thisx) {
@@ -1015,6 +1004,7 @@ void func_80B0EEA4(GlobalContext* globalCtx) {
 void EnSw_Draw(Actor* thisx, GlobalContext* globalCtx) {
     EnSw* this = (EnSw*)thisx;
     Color_RGBA8 sp30 = { 184, 0, 228, 255 };
+
     if (((this->actor.params & 0xE000) >> 0xD) != 0) {
         Matrix_RotateX(DEGF_TO_RADF(-80), MTXMODE_APPLY);
         if (this->actor.colChkInfo.health != 0) {

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.h
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.h
@@ -17,11 +17,11 @@ typedef struct EnSw {
     /* 0x01F4 */ Color_RGBA8 unk_1F4;
     /* 0x01F8 */ Vec3s jointTable[30];
     /* 0x02AC */ Vec3s morphTable[30];
-    /* 0x0360 */ u8 unk_360;
+    /* 0x0360 */ u8 velocityY;                  //unk_360;
     /* 0x0364 */ Vec3f unk_364;
     /* 0x0370 */ Vec3f unk_370;
     /* 0x037C */ Vec3f unk_37C;
-    /* 0x0388 */ s16 unk_388;
+    /* 0x0388 */ s16 RandOffset1030;            //unk_388;
     /* 0x038A */ s16 unk_38A;
     /* 0x038C */ s16 unk_38C;
     /* 0x038E */ s16 unk_38E;
@@ -37,8 +37,8 @@ typedef struct EnSw {
     /* 0x0430 */ CollisionPoly* unk_430;
     /* 0x0434 */ Vec3f unk_434;
     /* 0x0440 */ s16 unk_440;
-    /* 0x0442 */ s16 unk_442;
-    /* 0x0444 */ s16 unk_444;
+    /* 0x0442 */ s16 RandOffset2010;            //unk_442;
+    /* 0x0444 */ s16 newShapeRotZ;              //unk_444;
     /* 0x0446 */ s16 unk_446;
     /* 0x0448 */ Vec3f unk_448;
     /* 0x0454 */ Vec3f unk_454;
@@ -46,7 +46,7 @@ typedef struct EnSw {
     /* 0x046C */ Vec3f unk_46C;
     /* 0x0478 */ Vec3f unk_478;
     /* 0x0484 */ Vec3f unk_484;
-    /* 0x0490 */ char unk_490[0x48];
+    /* 0x0490 */ char unk_490[0x48];            //Unused?
 } EnSw; // size = 0x04D8
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.h
+++ b/soh/src/overlays/actors/ovl_En_Sw/z_en_sw.h
@@ -17,11 +17,11 @@ typedef struct EnSw {
     /* 0x01F4 */ Color_RGBA8 unk_1F4;
     /* 0x01F8 */ Vec3s jointTable[30];
     /* 0x02AC */ Vec3s morphTable[30];
-    /* 0x0360 */ u8 velocityY;                  //unk_360;
+    /* 0x0360 */ u8 unk_360;
     /* 0x0364 */ Vec3f unk_364;
     /* 0x0370 */ Vec3f unk_370;
     /* 0x037C */ Vec3f unk_37C;
-    /* 0x0388 */ s16 RandOffset1030;            //unk_388;
+    /* 0x0388 */ s16 unk_388;
     /* 0x038A */ s16 unk_38A;
     /* 0x038C */ s16 unk_38C;
     /* 0x038E */ s16 unk_38E;
@@ -37,8 +37,8 @@ typedef struct EnSw {
     /* 0x0430 */ CollisionPoly* unk_430;
     /* 0x0434 */ Vec3f unk_434;
     /* 0x0440 */ s16 unk_440;
-    /* 0x0442 */ s16 RandOffset2010;            //unk_442;
-    /* 0x0444 */ s16 newShapeRotZ;              //unk_444;
+    /* 0x0442 */ s16 unk_442;
+    /* 0x0444 */ s16 unk_444;
     /* 0x0446 */ s16 unk_446;
     /* 0x0448 */ Vec3f unk_448;
     /* 0x0454 */ Vec3f unk_454;
@@ -46,7 +46,7 @@ typedef struct EnSw {
     /* 0x046C */ Vec3f unk_46C;
     /* 0x0478 */ Vec3f unk_478;
     /* 0x0484 */ Vec3f unk_484;
-    /* 0x0490 */ char unk_490[0x48];            //Unused?
+    /* 0x0490 */ char unk_490[0x48];
 } EnSw; // size = 0x04D8
 
 #endif

--- a/soh/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
+++ b/soh/src/overlays/actors/ovl_En_fHG/z_en_fhg.c
@@ -332,7 +332,7 @@ void EnfHG_Intro(EnfHG* this, GlobalContext* globalCtx) {
             Math_ApproachF(&this->cameraSpeedMod, 1.0f, 1.0f, 0.05f);
             if (this->timers[0] == 75) {
                 TitleCard_InitBossName(globalCtx, &globalCtx->actorCtx.titleCtx,
-                                       SEGMENTED_TO_VIRTUAL(gPhantomGanonTitleCardTex), 160, 180, 128, 40);
+                                       SEGMENTED_TO_VIRTUAL(gPhantomGanonTitleCardTex), 160, 180, 128, 40, true);
             }
             if (this->timers[0] == 0) {
                 this->cutsceneState = INTRO_RETREAT;

--- a/soh/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/soh/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -106,7 +106,7 @@ s32 ObjTsubo_SnapToFloor(ObjTsubo* this, GlobalContext* globalCtx) {
     f32 floorY;
 
     pos.x = this->actor.world.pos.x;
-    pos.y = this->actor.world.pos.y + 20.0f;
+    pos.y = this->actor.world.pos.y + 10.0f;
     pos.z = this->actor.world.pos.z;
     floorY = BgCheck_EntityRaycastFloor4(&globalCtx->colCtx, &floorPoly, &bgID, &this->actor, &pos);
     if (floorY > BGCHECK_Y_MIN) {

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -19,6 +19,7 @@
 #include "overlays/effects/ovl_Effect_Ss_Fhg_Flash/z_eff_ss_fhg_flash.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_link_child/object_link_child.h"
+#include "objects/object_link_boy/object_link_boy.h"
 #include "textures/icon_item_24_static/icon_item_24_static.h"
 
 typedef struct {
@@ -10897,8 +10898,7 @@ void Player_DrawGameplay(GlobalContext* globalCtx, Player* this, s32 lod, Gfx* c
 void Player_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     Player* this = (Player*)thisx;
-
-     Vec3f pos;
+    Vec3f pos;
     Vec3s rot;
     f32 scale;
 

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10284,7 +10284,13 @@ void func_80848EF8(GlobalContext* globalCtx, Player* this) {
             int rectWidth   = 24; //Texture Width
             int rectHeight  = 24; //Texture Heigh
             int DefaultIconA= 50; //Default icon alphe (55 on 255)
-
+            if (CVar_GetS32("gHUDMargins", 0) != 0) {
+                rectLeft = OTRGetRectDimensionFromLeftEdge(26+(CVar_GetS32("gHUDMargin_L", 0)*-1));
+                rectTop = 60+(CVar_GetS32("gHUDMargin_T", 0)*-1);
+            } else {
+                rectTop = 60;
+                rectLeft = OTRGetRectDimensionFromLeftEdge(26);
+            }
             OPEN_DISPS(globalCtx->state.gfxCtx, "../z_player.c", 2824);
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, DefaultIconA);


### PR DESCRIPTION
Added : Reduce input lag by one frame by reading the controller at the correct place #244
Added : Bosses title cards fixes #247
Added : Fix dungeon entrance icon + feature #252
Added : Fixed Room backgrounds, lens of truth, circle fbdemo and sandstorm #254
Added : Basic UI placement edit into Cosmetics -> interface.
Added : Add option to bring player to the last entrance they came through when they load the game. #267
Added : WIP Visual in Zelda Time clock (MM vibe)
Added : Add option to disable black bars letterboxes #266
Added : Fix crash if LoadFile fails #265
Added : Add QoL feature: Faster Block Pushing #268
Fix Empty C button not being colored by color mod.
Fix console double rendering.
Fix Debug camera stuff overwriting gaming camera (ocarina issues and noises)
Moved Anti-aliasing from Graphic menu to Enhancements -> graphic
Debug -> Added a slider used for various test no used by any mods or feature, only there to bind to thing I need to test.
Workaround Intel OpenGL driver in get pixel depth